### PR TITLE
docs: add Read the Docs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,22 +1,18 @@
-# Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
-# Required
 version: 2
 
-# Set the OS, Python version, and other tools you might need
 build:
   os: ubuntu-24.04
+  apt_packages:
+    - libsodium-dev
   tools:
-    python: "3.14"
+    python: "3.13"
 
-# Build documentation in the "docs/" directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+  configuration: docs/conf.py
+  builder: dirhtml
 
-# Optionally, but recommended,
-# declare the Python requirements required to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+  install:
+    - method: pip
+      path: .
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,14 @@ extensions = [
 
 autosummary_generate = True
 autodoc_member_order = "bysource"
+autodoc_mock_imports = [
+    "falcon",
+    "hio",
+    "keri",
+    "multicommand",
+    "ordered_set",
+    "pyotp",
+]
 napoleon_include_init_with_doc = True
 
 templates_path = ["_templates"]
@@ -50,4 +58,7 @@ if sphinx_rtd_theme:
 else:
     html_theme = "alabaster"
 
-html_static_path = ["_static"]
+STATIC_DIR = os.path.join(os.path.dirname(__file__), "_static")
+
+if os.path.isdir(STATIC_DIR):
+    html_static_path = ["_static"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
-sphinx-rtd-theme
--e ..
+Sphinx>=8.1.3,<9
+ordered-set>=4.1.0
+sphinx-rtd-theme>=3.0.1,<4


### PR DESCRIPTION
RTD is currently failing on upstream `main` because commit `202662d` added a minimal `.readthedocs.yaml` that sets Python 3.14 but does not install the package or `libsodium-dev`. Sphinx can't import `witopnet` and the build dies.

This PR fixes the config:
- Pins Python to 3.13
- Adds `libsodium-dev` to `apt_packages`
- Installs the package with `method: pip path: .`
- Pins `docs/requirements.txt` to validated Sphinx/theme versions
- Also hardens `docs/conf.py` autodoc mock imports so the build is resilient to missing optional deps

Sphinx build passes locally. No runtime or service changes. Ready to merge.