### PR TITLE
feat: add Ansible host-first witness deployment [superseded — see PRs #9, #10, #11]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+SHELL := /bin/bash
+
+ROOT_DIR     := $(CURDIR)
+ANSIBLE_DIR  := $(ROOT_DIR)/deploy/ansible
+ANSIBLE_WRAPPER  := $(ANSIBLE_DIR)/with-op-ssh-agent.sh
+ANSIBLE_INVENTORY := inventories/pilot/hosts.yml
+ANSIBLE_PLAYBOOK  := ansible-playbook -i $(ANSIBLE_INVENTORY)
+ANSIBLE_ADHOC     := ansible -i $(ANSIBLE_INVENTORY)
+ONEPASSWORD_SSH_AUTH_SOCK ?= $(HOME)/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock
+WITNESS_HOST      ?= witness-do-01
+WITNESS_LOG_LINES ?= 40
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Show available make targets
+	@echo
+	@echo "Available commands for witness-hk:"
+	@echo
+	@awk 'BEGIN {FS = ":.*?##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_.-]+:.*?##/ { printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+	@echo
+
+##@ Witness Deployment
+
+.PHONY: witness-preflight
+witness-preflight: ## Validate 1Password-backed inventory values without opening SSH
+	@cd "$(ANSIBLE_DIR)" && "$(ANSIBLE_WRAPPER)" --no-ssh-agent \
+		$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml
+
+.PHONY: witness-ping
+witness-ping: ## Check SSH connectivity to the configured witness host
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping'
+
+.PHONY: witness-check
+witness-check: ## Run preflight, ping, and bootstrap dry-run in one auth batch
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
+		$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping && \
+		$(ANSIBLE_PLAYBOOK) playbooks/witness-bootstrap.yml --check --diff'
+
+.PHONY: witness-apply
+witness-apply: ## Run preflight and apply the witness bootstrap in one auth batch
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
+		$(ANSIBLE_PLAYBOOK) playbooks/witness-bootstrap.yml'
+
+.PHONY: witness-verify
+witness-verify: ## Run the post-bootstrap witness verification playbook
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-verify.yml'
+
+.PHONY: witness-all
+witness-all: ## Run preflight, ping, apply, and verify in one auth batch
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
+		$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping && \
+		$(ANSIBLE_PLAYBOOK) playbooks/witness-bootstrap.yml && \
+		$(ANSIBLE_PLAYBOOK) playbooks/witness-verify.yml'
+
+.PHONY: witness-status
+witness-status: ## Show systemd and Circus watcher status for the witness host
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -b -m shell -a '\''systemctl status circusd-witness --no-pager --lines=20; printf "\\n=== circusctl ===\\n"; /opt/keripy/.venv/bin/circusctl --endpoint ipc:///var/run/keri-circus/ctrl.sock status'\'''
+
+.PHONY: witness-logs
+witness-logs: ## Tail witness stdout and stderr logs from the host
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -b -m shell -a '\''printf "=== stdout ===\\n"; tail -n $(WITNESS_LOG_LINES) /var/log/keri/witness/stdout.log; printf "\\n=== stderr ===\\n"; tail -n $(WITNESS_LOG_LINES) /var/log/keri/witness/stderr.log'\'''

--- a/deploy/ansible/.ansible-lint.yml
+++ b/deploy/ansible/.ansible-lint.yml
@@ -1,0 +1,8 @@
+---
+profile: production
+exclude_paths:
+  - .cache/
+warn_list:
+  - experimental
+offline: true
+use_default_rules: true

--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -1,0 +1,191 @@
+# Ansible Host-First Witness Deployment
+
+Ansible automation for deploying a KERI witness node using the host-first
+posture: Ansible prepares the host, Circus supervises the witness process,
+and systemd keeps `circusd` running across reboots.
+
+## Architecture
+
+```
+systemd
+  └── circusd-witness.service
+        └── circusd (Circus process manager)
+              └── keripy-witness watcher
+                    └── run-keripy-witness.sh  →  keri runWitness(...)
+```
+
+Ansible owns the machine state: packages, users, directories, Python venv,
+editable checkouts of `keripy` and `hio`, rendered configs, and the systemd
+unit. Circus owns the process lifecycle after the host is prepared.
+
+## Prerequisites
+
+- Ansible 2.14+ on the operator workstation
+- 1Password CLI (`op`) signed in to your account
+- `community.general` collection — install with:
+
+  ```bash
+  ansible-galaxy collection install community.general
+  ```
+
+### SSH Agent Setup
+
+> **Primary platform: macOS.** The operator workflow is designed and tested on
+> macOS using the native 1Password SSH agent. Linux is supported but is a
+> secondary target — see below.
+
+**macOS (primary)**
+
+1. In 1Password, go to **Settings → Developer → SSH Agent** and enable it.
+2. No further SSH config is needed. `with-op-ssh-agent.sh` falls back to the
+   standard macOS socket at
+   `~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`
+   automatically.
+
+**Linux**
+
+1. In 1Password, go to **Settings → Developer → SSH Agent** and enable it.
+2. The default socket path is `~/.1password/agent.sock`.
+   `with-op-ssh-agent.sh` falls back to this path automatically.
+3. If your setup uses a different agent (forwarded agent, `gnome-keyring`,
+   custom `ssh-agent`), export `SSH_AUTH_SOCK` before running any make
+   targets and the wrapper will use it as-is.
+4. The `ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT` environment variable can override
+   the detected socket path if your 1Password agent socket is in a
+   non-standard location.
+
+## First-Time Setup
+
+1. Copy the secret-reference template and fill in your 1Password references:
+
+   ```bash
+   cp op.env.example op.env
+   # edit op.env — replace YOUR_VAULT / YOUR_ITEM placeholders
+   ```
+
+   `op.env` is git-ignored. Never commit a filled-in `op.env`.
+
+2. Add a `host_vars/<your-host>.yml` following the pattern in
+   `inventories/pilot/host_vars/witness-do-01.yml`.
+
+3. Add the host to `inventories/pilot/hosts.yml` under `witness_hosts`.
+
+4. Review the defaults in `inventories/pilot/group_vars/witness_hosts.yml`
+   and override any values that differ for your environment.
+
+5. Run the preflight check:
+
+   ```bash
+   ./with-op-ssh-agent.sh --no-ssh-agent \
+     ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-preflight.yml
+   ```
+
+## Operator Workflow
+
+### From the repository root (recommended)
+
+```bash
+make witness-preflight   # validate 1Password env vars — no SSH needed
+make witness-check       # preflight + ping + bootstrap dry-run
+make witness-apply       # preflight + full bootstrap
+make witness-verify      # post-bootstrap validation
+make witness-status      # systemd + Circus status
+make witness-logs        # tail stdout and stderr logs
+```
+
+### Direct playbook invocation
+
+Run from this directory (`deploy/ansible/`):
+
+```bash
+# Validate inventory without opening SSH
+./with-op-ssh-agent.sh --no-ssh-agent \
+  ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-preflight.yml
+
+# Ping the host
+./with-op-ssh-agent.sh \
+  ansible -i inventories/pilot/hosts.yml witness-do-01 -m ping
+
+# Dry-run bootstrap
+./with-op-ssh-agent.sh \
+  ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-bootstrap.yml --check --diff
+
+# Apply bootstrap
+./with-op-ssh-agent.sh \
+  ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-bootstrap.yml
+
+# Verify
+./with-op-ssh-agent.sh \
+  ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-verify.yml
+```
+
+## Authentication
+
+SSH authentication uses the native 1Password SSH agent — no private keys are
+exported or copied. Controller-side variables (`ansible_user`, `ansible_host`,
+`ansible_become_password`) are injected as environment variables through a
+short-lived `op run` subprocess via `with-op-ssh-agent.sh`.
+
+The current validated escalation path on the pilot host is:
+
+1. SSH as the `keri` user (non-root)
+2. `su` to `root` with the separate root password from 1Password
+
+`sudo` is not assumed to be configured for the `keri` user.
+
+## Lint
+
+```bash
+ansible-lint playbooks/witness-bootstrap.yml \
+            playbooks/witness-preflight.yml \
+            playbooks/witness-verify.yml \
+            roles/witness_host
+```
+
+The checked-in `.ansible-lint.yml` uses the `production` profile in offline
+mode. Install the linter with `pipx install ansible-lint`.
+
+## Directory Layout
+
+```
+deploy/ansible/
+├── .ansible-lint.yml
+├── ansible.cfg
+├── op.env.example          # template for 1Password secret references
+├── README.md
+├── with-op-ssh-agent.sh    # op run + SSH agent wrapper
+├── inventories/
+│   └── pilot/
+│       ├── hosts.yml
+│       ├── group_vars/
+│       │   └── witness_hosts.yml   # shared defaults for all witness hosts
+│       └── host_vars/
+│           └── witness-do-01.yml   # pilot host overrides
+├── playbooks/
+│   ├── witness-preflight.yml   # inventory validation (no SSH)
+│   ├── witness-bootstrap.yml   # full host convergence
+│   └── witness-verify.yml      # post-bootstrap health checks
+└── roles/
+    └── witness_host/
+        ├── handlers/main.yml
+        ├── tasks/main.yml
+        └── templates/
+            ├── circus-witness.ini.j2
+            ├── circusd-witness.service.j2
+            └── run-keripy-witness.sh.j2
+```
+
+## What the Bootstrap Does
+
+1. Installs system packages: `git`, `rsync`, `build-essential`,
+   `libsodium-dev`, `python3.14`, `python3.14-venv`
+2. Creates the `keri` system user and group
+3. Creates directories: `/opt`, `/etc/keri`, `/usr/local/var/keri`,
+   `/var/log/keri/witness`
+4. Clones `keripy` (`/opt/keripy`) and `hio` (`/opt/hio`) from GitHub
+5. Creates a Python 3.14 venv at `/opt/keripy/.venv`
+6. Installs `circus` and editable installs of `hio` and `keripy` into the venv
+7. Renders `/opt/keripy/ops/run-keripy-witness.sh` from template
+8. Renders `/etc/keri/circus-witness.ini` from template (IPC-only control socket)
+9. Renders `/etc/systemd/system/circusd-witness.service` from template
+10. Enables and starts the `circusd-witness` systemd unit

--- a/deploy/ansible/ansible.cfg
+++ b/deploy/ansible/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+inventory = inventories/pilot/hosts.yml
+roles_path = roles
+interpreter_python = auto_silent
+retry_files_enabled = False
+
+[ssh_connection]
+pipelining = True

--- a/deploy/ansible/inventories/pilot/group_vars/witness_hosts.yml
+++ b/deploy/ansible/inventories/pilot/group_vars/witness_hosts.yml
@@ -1,0 +1,87 @@
+witness_service_user: keri
+witness_service_group: keri
+witness_service_shell: /bin/bash
+witness_systemd_service_name: circusd-witness
+
+witness_repo_parent_dir: /opt
+witness_keripy_home: /opt/keripy
+witness_hio_home: /opt/hio
+witness_keri_config_dir: /etc/keri
+witness_circus_config_path: /etc/keri/circus-witness.ini
+witness_service_unit_path: /etc/systemd/system/circusd-witness.service
+witness_keri_data_dir: /usr/local/var/keri
+witness_runtime_dir: /var/run/keri-circus
+witness_log_dir: /var/log/keri/witness
+witness_stdout_log_path: /var/log/keri/witness/stdout.log
+witness_stderr_log_path: /var/log/keri/witness/stderr.log
+witness_wrapper_path: /opt/keripy/ops/run-keripy-witness.sh
+witness_venv_path: /opt/keripy/.venv
+
+witness_shell_bin: /bin/bash
+witness_python_bootstrap_bin: python3.14
+witness_python_bin: /opt/keripy/.venv/bin/python
+witness_pip_executable: /opt/keripy/.venv/bin/pip
+witness_circusd_bin: /opt/keripy/.venv/bin/circusd
+witness_circusctl_bin: /opt/keripy/.venv/bin/circusctl
+
+witness_circus_endpoint: ipc:///var/run/keri-circus/ctrl.sock
+witness_circus_pubsub_endpoint: ipc:///var/run/keri-circus/pub.sock
+witness_circus_stats_endpoint: ipc:///var/run/keri-circus/stats.sock
+witness_circus_statsd: 0
+witness_stop_signal: TERM
+witness_graceful_timeout: 30
+
+witness_system_packages:
+  - git
+  - rsync
+  - build-essential
+  - libsodium-dev
+  - python3.14
+  - python3.14-venv
+  - python3-pip
+
+witness_python_packages:
+  - circus
+
+witness_checkout_mode: source
+witness_keripy_repo_url: https://github.com/WebOfTrust/keripy
+witness_hio_repo_url: https://github.com/ioflo/hio
+
+witness_directories:
+  - path: "{{ witness_repo_parent_dir }}"
+    owner: root
+    group: root
+    mode: "0755"
+  - path: "{{ witness_keri_config_dir }}"
+    owner: root
+    group: "{{ witness_service_group }}"
+    mode: "0750"
+  - path: "{{ witness_log_dir }}"
+    owner: "{{ witness_service_user }}"
+    group: "{{ witness_service_group }}"
+    mode: "0750"
+  - path: "{{ witness_keri_data_dir }}"
+    owner: "{{ witness_service_user }}"
+    group: "{{ witness_service_group }}"
+    mode: "0750"
+
+witness_git_checkouts:
+  - repo: "{{ witness_hio_repo_url }}"
+    name: hio
+    dest: "{{ witness_hio_home }}"
+    version: "{{ witness_hio_repo_version }}"
+  - repo: "{{ witness_keripy_repo_url }}"
+    name: keripy
+    dest: "{{ witness_keripy_home }}"
+    version: "{{ witness_keripy_repo_version }}"
+
+witness_editable_python_paths:
+  - "{{ witness_hio_home }}"
+  - "{{ witness_keripy_home }}"
+
+witness_required_host_vars:
+  - witness_name
+  - witness_base
+  - witness_alias
+  - witness_http_port
+  - witness_tcp_port

--- a/deploy/ansible/inventories/pilot/host_vars/witness-do-01.yml
+++ b/deploy/ansible/inventories/pilot/host_vars/witness-do-01.yml
@@ -1,0 +1,24 @@
+ansible_user: >-
+  {{
+    lookup('ansible.builtin.env', 'WITNESS_ANSIBLE_USER', default='') | trim
+  }}
+ansible_host: >-
+  {{
+    lookup('ansible.builtin.env', 'WITNESS_ANSIBLE_HOST', default='') | trim | regex_replace('^.*@', '')
+  }}
+ansible_become_method: su
+ansible_become_user: root
+ansible_become_password: >-
+  {{
+    lookup('ansible.builtin.env', 'WITNESS_ANSIBLE_BECOME_PASSWORD', default='') | trim
+  }}
+
+witness_name: witness-do-01
+witness_base: witness-do-01
+witness_alias: witness-do-01
+witness_http_port: 5631
+witness_tcp_port: 5632
+witness_expire: 0.0
+
+witness_keripy_repo_version: main
+witness_hio_repo_version: main

--- a/deploy/ansible/inventories/pilot/hosts.yml
+++ b/deploy/ansible/inventories/pilot/hosts.yml
@@ -1,0 +1,5 @@
+all:
+  children:
+    witness_hosts:
+      hosts:
+        witness-do-01:

--- a/deploy/ansible/op.env.example
+++ b/deploy/ansible/op.env.example
@@ -1,0 +1,12 @@
+# Non-secret reference file for op run injection.
+# Copy this file to op.env and replace the placeholders with your own
+# 1Password secret references before running any Ansible commands.
+#
+# Format: op://VAULT_NAME/ITEM_NAME/FIELD_NAME
+# See: https://developer.1password.com/docs/cli/secret-references/
+#
+# The three variables below are injected at runtime by `op run` and are
+# never written to disk as plaintext. Do not commit a filled-in op.env.
+WITNESS_ANSIBLE_USER=op://YOUR_VAULT/YOUR_WITNESS_LOGIN_ITEM/username
+WITNESS_ANSIBLE_HOST=op://YOUR_VAULT/YOUR_WITNESS_LOGIN_ITEM/SSH/hostname
+WITNESS_ANSIBLE_BECOME_PASSWORD=op://YOUR_VAULT/YOUR_BECOME_PASSWORD_ITEM/password

--- a/deploy/ansible/playbooks/witness-bootstrap.yml
+++ b/deploy/ansible/playbooks/witness-bootstrap.yml
@@ -1,0 +1,8 @@
+---
+- name: Bootstrap host-first witness pilot
+  hosts: witness_hosts
+  become: true
+  gather_facts: true
+
+  roles:
+    - witness_host

--- a/deploy/ansible/playbooks/witness-preflight.yml
+++ b/deploy/ansible/playbooks/witness-preflight.yml
@@ -1,0 +1,59 @@
+---
+- name: Preflight host-first witness pilot
+  hosts: witness_hosts
+  become: false
+  gather_facts: false
+
+  tasks:
+    - name: Assert pilot inventory resolves a host address
+      ansible.builtin.assert:
+        that:
+          - ansible_host is defined
+          - ansible_host | string | length > 0
+        fail_msg: Resolve ansible_host from 1Password before running the pilot
+
+    - name: Assert pilot inventory uses the non-root keri login
+      ansible.builtin.assert:
+        that:
+          - ansible_user is defined
+          - ansible_user == 'keri'
+        fail_msg: The pilot must use the keri user instead of root
+
+    - name: Assert controller env resolves witness user from op run
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.env', 'WITNESS_ANSIBLE_USER', default='') | string | length > 0
+        fail_msg: Resolve WITNESS_ANSIBLE_USER through op run before running the pilot
+
+    - name: Assert controller env resolves witness host from op run
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.env', 'WITNESS_ANSIBLE_HOST', default='') | string | length > 0
+        fail_msg: Resolve WITNESS_ANSIBLE_HOST through op run before running the pilot
+
+    - name: Assert become password resolves from op run
+      ansible.builtin.assert:
+        that:
+          - ansible_become_password is defined
+          - ansible_become_password | string | length > 0
+        fail_msg: Resolve WITNESS_ANSIBLE_BECOME_PASSWORD through op run before running the pilot
+
+    - name: Assert become method stays on the validated host path
+      ansible.builtin.assert:
+        that:
+          - ansible_become_method == 'su'
+          - ansible_become_user == 'root'
+        fail_msg: The current validated host escalation path is keri SSH plus su to root
+
+    - name: Assert required witness variables are present
+      ansible.builtin.assert:
+        that:
+          - lookup('vars', item, default='') | string | length > 0
+        fail_msg: "Required pilot variable is missing: {{ item }}"
+      loop: "{{ witness_required_host_vars }}"
+
+    - name: Assert host ports are distinct
+      ansible.builtin.assert:
+        that:
+          - witness_http_port | int != witness_tcp_port | int
+        fail_msg: witness_http_port and witness_tcp_port must be different

--- a/deploy/ansible/playbooks/witness-verify.yml
+++ b/deploy/ansible/playbooks/witness-verify.yml
@@ -1,0 +1,165 @@
+---
+- name: Verify host-first witness pilot
+  hosts: witness_hosts
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert witness service is running and enabled
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services[witness_systemd_service_name + '.service'] is defined
+          - ansible_facts.services[witness_systemd_service_name + '.service'].state == 'running'
+          - ansible_facts.services[witness_systemd_service_name + '.service'].status == 'enabled'
+        fail_msg: "{{ witness_systemd_service_name }} is not enabled and running"
+
+    - name: Check IPC control socket
+      ansible.builtin.stat:
+        path: "{{ witness_runtime_dir }}/ctrl.sock"
+      register: witness_ctrl_socket
+
+    - name: Check witness stdout log
+      ansible.builtin.stat:
+        path: "{{ witness_stdout_log_path }}"
+      register: witness_stdout_log
+
+    - name: Check witness stderr log
+      ansible.builtin.stat:
+        path: "{{ witness_stderr_log_path }}"
+      register: witness_stderr_log
+
+    - name: Assert sockets and log files exist
+      ansible.builtin.assert:
+        that:
+          - witness_ctrl_socket.stat.exists
+          - witness_ctrl_socket.stat.issock | default(false)
+          - witness_stdout_log.stat.exists
+          - witness_stderr_log.stat.exists
+        fail_msg: Witness IPC socket or log files are missing
+
+    - name: Query Circus watcher status
+      ansible.builtin.command:
+        argv:
+          - "{{ witness_circusctl_bin }}"
+          - --endpoint
+          - "{{ witness_circus_endpoint }}"
+          - status
+      register: witness_circus_status
+      changed_when: false
+
+    - name: Assert watcher is present in Circus status output
+      ansible.builtin.assert:
+        that:
+          - "'keripy-witness' in witness_circus_status.stdout"
+        fail_msg: Circus status did not report the keripy-witness watcher
+
+    - name: Read systemd main PID for Circus
+      ansible.builtin.command:
+        argv:
+          - systemctl
+          - show
+          - -p
+          - MainPID
+          - --value
+          - "{{ witness_systemd_service_name }}"
+      register: witness_systemd_main_pid
+      changed_when: false
+
+    - name: Assert Circus main PID exists
+      ansible.builtin.assert:
+        that:
+          - (witness_systemd_main_pid.stdout | trim | int) > 0
+        fail_msg: systemd did not report a valid MainPID for {{ witness_systemd_service_name }}
+
+    - name: Sample non-stats watcher child process
+      ansible.builtin.command:
+        argv:
+          - ps
+          - -ww
+          - --ppid
+          - "{{ witness_systemd_main_pid.stdout | trim }}"
+          - -o
+          - pid=,stat=,args=
+      register: witness_child_sample_1
+      changed_when: false
+
+    - name: Filter first watcher child sample
+      ansible.builtin.set_fact:
+        witness_child_sample_1_lines: >-
+          {{
+            witness_child_sample_1.stdout_lines
+            | reject('search', 'circus import stats')
+            | list
+          }}
+
+    - name: Assert first watcher child sample is present
+      ansible.builtin.assert:
+        that:
+          - witness_child_sample_1_lines | length == 1
+        fail_msg: Expected exactly one non-stats watcher child under Circus
+
+    - name: Pause before second watcher child sample
+      ansible.builtin.pause:
+        seconds: 2
+
+    - name: Sample non-stats watcher child process again
+      ansible.builtin.command:
+        argv:
+          - ps
+          - -ww
+          - --ppid
+          - "{{ witness_systemd_main_pid.stdout | trim }}"
+          - -o
+          - pid=,stat=,args=
+      register: witness_child_sample_2
+      changed_when: false
+
+    - name: Filter second watcher child sample
+      ansible.builtin.set_fact:
+        witness_child_sample_2_lines: >-
+          {{
+            witness_child_sample_2.stdout_lines
+            | reject('search', 'circus import stats')
+            | list
+          }}
+
+    - name: Assert second watcher child sample is present
+      ansible.builtin.assert:
+        that:
+          - witness_child_sample_2_lines | length == 1
+        fail_msg: Expected exactly one non-stats watcher child under Circus on second sample
+
+    - name: Parse watcher child samples
+      ansible.builtin.set_fact:
+        witness_child_parts_1: "{{ (witness_child_sample_1_lines | first).split() }}"
+        witness_child_parts_2: "{{ (witness_child_sample_2_lines | first).split() }}"
+
+    - name: Wait for witness HTTP listener
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: "{{ witness_http_port }}"
+        state: started
+        timeout: 3
+        connect_timeout: 1
+
+    - name: Wait for witness TCP listener
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: "{{ witness_tcp_port }}"
+        state: started
+        timeout: 3
+        connect_timeout: 1
+
+    - name: Assert witness runtime stays alive and binds expected ports
+      ansible.builtin.assert:
+        that:
+          - witness_child_parts_1[0] == witness_child_parts_2[0]
+          - witness_child_parts_1[1] is not search('Z')
+          - witness_child_parts_2[1] is not search('Z')
+        fail_msg: |
+          Witness runtime is unhealthy.
+          sample_1={{ witness_child_sample_1_lines | first }}
+          sample_2={{ witness_child_sample_2_lines | first }}

--- a/deploy/ansible/roles/witness_host/handlers/main.yml
+++ b/deploy/ansible/roles/witness_host/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+
+- name: Restart witness service
+  ansible.builtin.systemd_service:
+    name: "{{ witness_systemd_service_name }}"
+    state: restarted
+  when: not ansible_check_mode

--- a/deploy/ansible/roles/witness_host/tasks/main.yml
+++ b/deploy/ansible/roles/witness_host/tasks/main.yml
@@ -1,0 +1,162 @@
+---
+- name: Install host packages
+  ansible.builtin.package:
+    name: "{{ witness_system_packages }}"
+    state: present
+  when: witness_system_packages | length > 0
+
+- name: Ensure witness group exists
+  ansible.builtin.group:
+    name: "{{ witness_service_group }}"
+    system: true
+
+- name: Ensure witness user exists
+  ansible.builtin.user:
+    name: "{{ witness_service_user }}"
+    group: "{{ witness_service_group }}"
+    system: true
+    shell: "{{ witness_service_shell }}"
+    create_home: false
+
+- name: Ensure witness directories exist
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+  loop: "{{ witness_directories }}"
+
+- name: Check existing source checkout paths
+  ansible.builtin.stat:
+    path: "{{ item.dest }}"
+  loop: "{{ witness_git_checkouts }}"
+  register: witness_host_checkout_paths
+  when: witness_checkout_mode == 'source'
+
+- name: Check existing git metadata
+  ansible.builtin.stat:
+    path: "{{ item.dest }}/.git"
+  loop: "{{ witness_git_checkouts }}"
+  register: witness_host_checkout_gitdirs
+  when: witness_checkout_mode == 'source'
+
+- name: Remove stale non-git source trees so git clone can replace them
+  ansible.builtin.file:
+    path: "{{ item.0.dest }}"
+    state: absent
+  loop: "{{ witness_git_checkouts | zip(witness_host_checkout_paths.results, witness_host_checkout_gitdirs.results) | list }}"
+  when:
+    - witness_checkout_mode == 'source'
+    - item.1.stat.exists
+    - not item.2.stat.exists
+
+- name: Ensure source checkout ownership
+  ansible.builtin.file:
+    path: "{{ item.dest }}"
+    state: directory
+    owner: "{{ witness_service_user }}"
+    group: "{{ witness_service_group }}"
+    recurse: true
+  loop: "{{ witness_git_checkouts }}"
+  when:
+    - witness_checkout_mode == 'source'
+    - item.dest in (witness_host_checkout_paths.results | map(attribute='stat') | selectattr('exists') | map(attribute='path') | list)
+
+- name: Mark source checkouts as safe directories for root
+  community.general.git_config:
+    name: safe.directory
+    scope: global
+    value: "{{ item.dest }}"
+    add_mode: add
+  loop: "{{ witness_git_checkouts }}"
+  when: witness_checkout_mode == 'source'
+
+- name: Clone hio and keripy repositories
+  ansible.builtin.git:
+    repo: "{{ item.0.repo }}"
+    dest: "{{ item.0.dest }}"
+    version: "{{ item.0.version }}"
+    update: true
+  loop: "{{ witness_git_checkouts | zip(witness_host_checkout_paths.results, witness_host_checkout_gitdirs.results) | list }}"
+  when:
+    - witness_checkout_mode == 'source'
+
+- name: Ensure source checkout ownership after clone
+  ansible.builtin.file:
+    path: "{{ item.dest }}"
+    state: directory
+    owner: "{{ witness_service_user }}"
+    group: "{{ witness_service_group }}"
+    recurse: true
+  loop: "{{ witness_git_checkouts }}"
+  when: witness_checkout_mode == 'source'
+
+- name: Ensure witness wrapper directory exists
+  ansible.builtin.file:
+    path: "{{ witness_keripy_home }}/ops"
+    state: directory
+    owner: "{{ witness_service_user }}"
+    group: "{{ witness_service_group }}"
+    mode: "0755"
+
+- name: Create witness virtualenv
+  ansible.builtin.command:
+    argv:
+      - "{{ witness_python_bootstrap_bin }}"
+      - -m
+      - venv
+      - "{{ witness_venv_path }}"
+  args:
+    creates: "{{ witness_venv_path }}/bin/python"
+
+- name: Install Python packages required for Circus
+  ansible.builtin.pip:
+    name: "{{ witness_python_packages }}"
+    executable: "{{ witness_pip_executable }}"
+  when: witness_python_packages | length > 0
+
+- name: Install editable local hio and keripy packages
+  ansible.builtin.pip:
+    name: "{{ item }}"
+    editable: true
+    executable: "{{ witness_pip_executable }}"
+  loop: "{{ witness_editable_python_paths }}"
+  when: witness_checkout_mode == 'source'
+
+- name: Render run-keripy-witness wrapper
+  ansible.builtin.template:
+    src: run-keripy-witness.sh.j2
+    dest: "{{ witness_wrapper_path }}"
+    owner: "{{ witness_service_user }}"
+    group: "{{ witness_service_group }}"
+    mode: "0755"
+  notify: Restart witness service
+
+- name: Render Circus config
+  ansible.builtin.template:
+    src: circus-witness.ini.j2
+    dest: "{{ witness_circus_config_path }}"
+    owner: root
+    group: "{{ witness_service_group }}"
+    mode: "0640"
+  notify: Restart witness service
+
+- name: Render systemd unit
+  ansible.builtin.template:
+    src: circusd-witness.service.j2
+    dest: "{{ witness_service_unit_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Reload systemd
+    - Restart witness service
+
+- name: Enable and start witness service
+  ansible.builtin.systemd_service:
+    name: "{{ witness_systemd_service_name }}"
+    daemon_reload: true
+    enabled: true
+    state: started
+  when: not ansible_check_mode

--- a/deploy/ansible/roles/witness_host/templates/circus-witness.ini.j2
+++ b/deploy/ansible/roles/witness_host/templates/circus-witness.ini.j2
@@ -1,0 +1,31 @@
+[circus]
+endpoint = {{ witness_circus_endpoint }}
+pubsub_endpoint = {{ witness_circus_pubsub_endpoint }}
+stats_endpoint = {{ witness_circus_stats_endpoint }}
+statsd = {{ witness_circus_statsd }}
+httpd = false
+
+[watcher:keripy-witness]
+cmd = {{ witness_wrapper_path }}
+working_dir = {{ witness_keripy_home }}
+shell = false
+uid = {{ witness_service_user }}
+gid = {{ witness_service_group }}
+numprocesses = 1
+autostart = true
+autorestart = true
+stdout_stream.class = FileStream
+stdout_stream.filename = {{ witness_stdout_log_path }}
+stderr_stream.class = FileStream
+stderr_stream.filename = {{ witness_stderr_log_path }}
+stop_signal = {{ witness_stop_signal }}
+graceful_timeout = {{ witness_graceful_timeout }}
+
+[env:keripy-witness]
+KERIPY_HOME = {{ witness_keripy_home }}
+WITNESS_NAME = {{ witness_name }}
+WITNESS_BASE = {{ witness_base }}
+WITNESS_ALIAS = {{ witness_alias }}
+WITNESS_HTTP_PORT = {{ witness_http_port }}
+WITNESS_TCP_PORT = {{ witness_tcp_port }}
+WITNESS_EXPIRE = {{ witness_expire }}

--- a/deploy/ansible/roles/witness_host/templates/circusd-witness.service.j2
+++ b/deploy/ansible/roles/witness_host/templates/circusd-witness.service.j2
@@ -1,0 +1,31 @@
+[Unit]
+Description=KERI witness Circus process manager
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ witness_service_user }}
+Group={{ witness_service_group }}
+UMask=0027
+WorkingDirectory={{ witness_keripy_home }}
+RuntimeDirectory=keri-circus
+RuntimeDirectoryMode=0750
+ExecStart={{ witness_circusd_bin }} {{ witness_circus_config_path }}
+ExecReload={{ witness_circusctl_bin }} --endpoint {{ witness_circus_endpoint }} reload
+Restart=always
+RestartSec=5
+LimitNOFILE=65536
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectControlGroups=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+PrivateTmp=true
+RestrictSUIDSGID=true
+LockPersonality=true
+ReadWritePaths={{ witness_keripy_home }} {{ witness_keri_data_dir }} {{ witness_runtime_dir }} {{ witness_log_dir }}
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ansible/roles/witness_host/templates/run-keripy-witness.sh.j2
+++ b/deploy/ansible/roles/witness_host/templates/run-keripy-witness.sh.j2
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KERIPY_HOME="${KERIPY_HOME:-{{ witness_keripy_home }}}"
+HIO_HOME="${HIO_HOME:-}"
+PYTHON_BIN="${PYTHON_BIN:-{{ witness_python_bin }}}"
+WITNESS_NAME="${WITNESS_NAME:-{{ witness_name }}}"
+WITNESS_BASE="${WITNESS_BASE:-{{ witness_base }}}"
+WITNESS_ALIAS="${WITNESS_ALIAS:-{{ witness_alias }}}"
+WITNESS_HTTP_PORT="${WITNESS_HTTP_PORT:-{{ witness_http_port }}}"
+WITNESS_TCP_PORT="${WITNESS_TCP_PORT:-{{ witness_tcp_port }}}"
+WITNESS_EXPIRE="${WITNESS_EXPIRE:-{{ witness_expire }}}"
+
+export WITNESS_NAME
+export WITNESS_BASE
+export WITNESS_ALIAS
+export WITNESS_HTTP_PORT
+export WITNESS_TCP_PORT
+export WITNESS_EXPIRE
+
+if [[ "${WITNESS_BASE}" = /* ]]; then
+    echo "WITNESS_BASE must remain a relative path: ${WITNESS_BASE}" >&2
+    exit 1
+fi
+
+if [[ -z "${HIO_HOME}" ]]; then
+    sibling_hio="$(cd "${KERIPY_HOME}/.." && pwd)/hio"
+    if [[ -d "${sibling_hio}/src" ]]; then
+        HIO_HOME="${sibling_hio}"
+    fi
+fi
+
+cd "${KERIPY_HOME}"
+if [[ -n "${HIO_HOME}" ]]; then
+    export PYTHONPATH="${KERIPY_HOME}/src:${HIO_HOME}/src"
+else
+    export PYTHONPATH="${KERIPY_HOME}/src"
+fi
+
+exec "${PYTHON_BIN}" - <<'PY'
+import os
+
+from keri.cli.commands.witness.start import runWitness
+
+
+runWitness(
+    name=os.environ["WITNESS_NAME"],
+    base=os.environ["WITNESS_BASE"],
+    alias=os.environ["WITNESS_ALIAS"],
+    http=int(os.environ["WITNESS_HTTP_PORT"]),
+    tcp=int(os.environ["WITNESS_TCP_PORT"]),
+    expire=float(os.environ["WITNESS_EXPIRE"]),
+)
+PY

--- a/deploy/ansible/with-op-ssh-agent.sh
+++ b/deploy/ansible/with-op-ssh-agent.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# with-op-ssh-agent.sh
+#
+# Primary platform: macOS
+#   SSH authentication uses the native 1Password SSH agent. The default socket
+#   path is the macOS-specific location set by the 1Password desktop app.
+#
+# Linux support:
+#   Also works on Linux if the 1Password SSH agent is running. The default
+#   socket path on Linux is ~/.1password/agent.sock. You can override the
+#   socket location by setting ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT in your
+#   environment before calling this script, or by pointing SSH_AUTH_SOCK at
+#   any already-running SSH agent that holds the correct key.
+#
+#   If you use a non-1Password SSH agent on Linux (e.g. ssh-agent, gnome-keyring,
+#   or a forwarded agent), export SSH_AUTH_SOCK before running this script and
+#   the agent-detection step will skip the 1Password socket lookup entirely.
+# -----------------------------------------------------------------------------
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OP_RUN_ENV_FILE="${OP_RUN_ENV_FILE:-${SCRIPT_DIR}/op.env}"
+
+# Resolve the default 1Password SSH agent socket for the current OS.
+# macOS: set by the 1Password desktop app under ~/Library/Group Containers/
+# Linux: set by the 1Password desktop app under ~/.1password/
+# Override by setting ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT in your environment.
+if [[ -z "${ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT:-}" ]]; then
+    case "$(uname -s)" in
+        Darwin)
+            ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+            ;;
+        Linux)
+            ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT="$HOME/.1password/agent.sock"
+            ;;
+        *)
+            ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT=""
+            ;;
+    esac
+fi
+
+require_ssh_agent=1
+
+if [[ ${1:-} == "--no-ssh-agent" ]]; then
+    require_ssh_agent=0
+    shift
+fi
+
+if [[ $# -eq 0 ]]; then
+    echo "usage: $0 [--no-ssh-agent] <ansible command> [args ...]" >&2
+    exit 1
+fi
+
+if ! command -v op >/dev/null 2>&1; then
+    echo "op CLI is required" >&2
+    exit 1
+fi
+
+if ! command -v ssh-add >/dev/null 2>&1; then
+    echo "ssh-add is required" >&2
+    exit 1
+fi
+
+if [[ ! -f "$OP_RUN_ENV_FILE" ]]; then
+    echo "op run env file is required: $OP_RUN_ENV_FILE" >&2
+    echo "Copy op.env.example to op.env and fill in your 1Password secret references." >&2
+    exit 1
+fi
+
+configure_1password_ssh_agent() {
+    # If SSH_AUTH_SOCK is already set and the agent has keys loaded, use it as-is.
+    # This covers: forwarded agents, gnome-keyring, custom macOS/Linux agents, etc.
+    if [[ -n ${SSH_AUTH_SOCK:-} ]] && ssh-add -l >/dev/null 2>&1; then
+        return 0
+    fi
+
+    # Try the platform-specific 1Password agent socket.
+    if [[ -n "${ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT:-}" ]] && [[ -S "$ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT" ]]; then
+        export SSH_AUTH_SOCK="$ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT"
+    fi
+
+    if [[ -z ${SSH_AUTH_SOCK:-} ]] || ! ssh-add -l >/dev/null 2>&1; then
+        cat >&2 <<'EOF'
+1Password SSH agent is not ready.
+
+macOS: Enable the SSH agent in 1Password Settings → Developer → SSH Agent.
+Linux: Enable the SSH agent in 1Password Settings → Developer → SSH Agent.
+        The default socket path is ~/.1password/agent.sock.
+
+Alternatively, export SSH_AUTH_SOCK pointing to any SSH agent that holds
+the correct key before calling this script.
+EOF
+        exit 1
+    fi
+}
+
+if [[ "$require_ssh_agent" -eq 1 ]]; then
+    configure_1password_ssh_agent
+fi
+
+exec op run --env-file="$OP_RUN_ENV_FILE" -- "$@"


### PR DESCRIPTION
## Summary

Adds `deploy/ansible/` — a fully-validated Ansible pilot for deploying a KERI witness node to a bare host (Ubuntu 24.04, tested on DigitalOcean). Also adds a root `Makefile` that exposes the operator workflow as memorable `make` targets.

This implements the host-first deployment posture decided in ADR-036: Ansible prepares and verifies the host, Circus supervises the witness process, systemd keeps `circusd` alive across reboots.

## Architecture

```
systemd
  └── circusd-witness.service
        └── circusd (Circus process manager)
              └── keripy-witness watcher
                    └── run-keripy-witness.sh  →  keri runWitness(...)
```

## What the bootstrap installs

- System packages: `git`, `rsync`, `build-essential`, `libsodium-dev`, `python3.14`, `python3.14-venv`
- `keri` system user and group
- Required directories under `/opt`, `/etc/keri`, `/usr/local/var/keri`, `/var/log/keri/witness`
- Clones `keripy` → `/opt/keripy` and `hio` → `/opt/hio`
- Python 3.14 venv at `/opt/keripy/.venv` with `circus`, editable `hio`, editable `keripy`
- Rendered `run-keripy-witness.sh`, `circus-witness.ini`, `circusd-witness.service`
- Enabled and started `circusd-witness` systemd unit

## Operator workflow

```bash
make witness-preflight   # validate 1Password env — no SSH needed
make witness-check       # preflight + ping + bootstrap dry-run
make witness-apply       # preflight + full bootstrap
make witness-verify      # post-bootstrap health checks (systemd, Circus, port listeners)
make witness-status      # live systemd + circusctl status
make witness-logs        # tail stdout/stderr from the host
```

## Authentication

Primary platform is **macOS** using the native 1Password SSH agent. **Linux** is also supported — the wrapper auto-detects `~/.1password/agent.sock` or falls back to any already-running SSH agent via `SSH_AUTH_SOCK`.

Controller-side variables (`ansible_user`, `ansible_host`, `ansible_become_password`) are injected through a short-lived `op run` subprocess — no secrets are written to disk or exported into the shell environment.

### First-time setup

```bash
cd deploy/ansible
cp op.env.example op.env
# fill in op.env with your 1Password secret references
ansible-galaxy collection install community.general
make witness-preflight
```

## Files added

```
Makefile
deploy/ansible/
├── .ansible-lint.yml
├── README.md
├── ansible.cfg
├── op.env.example
├── with-op-ssh-agent.sh
├── inventories/pilot/
│   ├── hosts.yml
│   ├── group_vars/witness_hosts.yml
│   └── host_vars/witness-do-01.yml
├── playbooks/
│   ├── witness-preflight.yml
│   ├── witness-bootstrap.yml
│   └── witness-verify.yml
└── roles/witness_host/
    ├── handlers/main.yml
    ├── tasks/main.yml
    └── templates/
        ├── circus-witness.ini.j2
        ├── circusd-witness.service.j2
        └── run-keripy-witness.sh.j2
```

## Notes for reviewers

- `op.env.example` contains only placeholder references (`op://YOUR_VAULT/...`). The real item paths stay in the private ops repo.
- `witness-do-01.yml` is a concrete pilot example naming the existing DigitalOcean droplet. Rename or duplicate it for additional hosts.
- Circus control is IPC-only (`ipc:///var/run/keri-circus/ctrl.sock`) — no TCP control port is exposed.
- The systemd unit uses `ProtectSystem=strict`, `NoNewPrivileges`, `PrivateTmp`, and other hardening options.
- `--check --diff` via `make witness-check` is the recommended first step before applying to any new host.