### PR TITLE
feat(deploy): add Ansible operator surface [1/3]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,9 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
+# Ansible operator secrets — copy op.env.example to op.env and fill in locally
+deploy/ansible/op.env
+
 # Cursor
 #  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
 #  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+SHELL := /bin/bash
+
+ROOT_DIR     := $(CURDIR)
+ANSIBLE_DIR  := $(ROOT_DIR)/deploy/ansible
+ANSIBLE_WRAPPER  := $(ANSIBLE_DIR)/with-op-ssh-agent.sh
+ANSIBLE_INVENTORY := inventories/pilot/hosts.yml
+ANSIBLE_PLAYBOOK  := ansible-playbook -i $(ANSIBLE_INVENTORY)
+ANSIBLE_ADHOC     := ansible -i $(ANSIBLE_INVENTORY)
+ONEPASSWORD_SSH_AUTH_SOCK ?= $(HOME)/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock
+WITNESS_HOST      ?= witness-do-01
+WITNESS_LOG_LINES ?= 40
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Show available make targets
+	@echo
+	@echo "Available commands for witness-hk:"
+	@echo
+	@awk 'BEGIN {FS = ":.*?##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_.-]+:.*?##/ { printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+	@echo
+
+##@ Witness Deployment
+
+.PHONY: witness-preflight
+witness-preflight: ## Validate 1Password-backed inventory values without opening SSH
+	@cd "$(ANSIBLE_DIR)" && "$(ANSIBLE_WRAPPER)" --no-ssh-agent \
+		$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml
+
+.PHONY: witness-ping
+witness-ping: ## Check SSH connectivity to the configured witness host
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping'
+
+.PHONY: witness-check
+witness-check: ## Run preflight, ping, and bootstrap dry-run in one auth batch
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
+		$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping && \
+		$(ANSIBLE_PLAYBOOK) playbooks/witness-bootstrap.yml --check --diff'
+
+.PHONY: witness-apply
+witness-apply: ## Run preflight and apply the witness bootstrap in one auth batch
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
+		$(ANSIBLE_PLAYBOOK) playbooks/witness-bootstrap.yml'
+
+.PHONY: witness-verify
+witness-verify: ## Run the post-bootstrap witness verification playbook
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-verify.yml'
+
+.PHONY: witness-all
+witness-all: ## Run preflight, ping, apply, and verify in one auth batch
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
+		$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping && \
+		$(ANSIBLE_PLAYBOOK) playbooks/witness-bootstrap.yml && \
+		$(ANSIBLE_PLAYBOOK) playbooks/witness-verify.yml'
+
+.PHONY: witness-status
+witness-status: ## Show systemd and Circus watcher status for the witness host
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -b -m shell -a '\''systemctl status circusd-witness --no-pager --lines=20; printf "\\n=== circusctl ===\\n"; /opt/keripy/.venv/bin/circusctl --endpoint ipc:///var/run/keri-circus/ctrl.sock status'\'''
+
+.PHONY: witness-logs
+witness-logs: ## Tail witness stdout and stderr logs from the host
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -b -m shell -a '\''printf "=== stdout ===\\n"; tail -n $(WITNESS_LOG_LINES) /var/log/keri/witness/stdout.log; printf "\\n=== stderr ===\\n"; tail -n $(WITNESS_LOG_LINES) /var/log/keri/witness/stderr.log'\'''

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,22 @@ ONEPASSWORD_SSH_AUTH_SOCK ?= $(HOME)/Library/Group Containers/2BUA8C4S2C.com.1pa
 WITNESS_HOST      ?= witness-do-01
 WITNESS_LOG_LINES ?= 40
 
+define require_witness_host
+[[ "$(WITNESS_HOST)" =~ ^[A-Za-z0-9_.-]+$$ ]] || { \
+	echo "Invalid WITNESS_HOST: $(WITNESS_HOST)" >&2; \
+	echo "Expected a single inventory hostname containing only letters, digits, dot, underscore, or dash." >&2; \
+	exit 1; \
+}
+endef
+
+define require_witness_log_lines
+[[ "$(WITNESS_LOG_LINES)" =~ ^[1-9][0-9]*$$ ]] || { \
+	echo "Invalid WITNESS_LOG_LINES: $(WITNESS_LOG_LINES)" >&2; \
+	echo "Expected WITNESS_LOG_LINES to be a positive integer." >&2; \
+	exit 1; \
+}
+endef
+
 .DEFAULT_GOAL := help
 
 .PHONY: help
@@ -29,11 +45,13 @@ witness-preflight: ## Validate 1Password-backed inventory values without opening
 
 .PHONY: witness-ping
 witness-ping: ## Check SSH connectivity to the configured witness host
+	@$(require_witness_host)
 	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping'
 
 .PHONY: witness-check
 witness-check: ## Run preflight, ping, and bootstrap dry-run in one auth batch
+	@$(require_witness_host)
 	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
 		$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping && \
@@ -52,6 +70,7 @@ witness-verify: ## Run the post-bootstrap witness verification playbook
 
 .PHONY: witness-all
 witness-all: ## Run preflight, ping, apply, and verify in one auth batch
+	@$(require_witness_host)
 	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
 		$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping && \
@@ -60,10 +79,13 @@ witness-all: ## Run preflight, ping, apply, and verify in one auth batch
 
 .PHONY: witness-status
 witness-status: ## Show systemd and Circus watcher status for the witness host
+	@$(require_witness_host)
 	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -b -m shell -a '\''systemctl status circusd-witness --no-pager --lines=20; printf "\\n=== circusctl ===\\n"; /opt/keripy/.venv/bin/circusctl --endpoint ipc:///var/run/keri-circus/ctrl.sock status'\'''
 
 .PHONY: witness-logs
 witness-logs: ## Tail witness stdout and stderr logs from the host
+	@$(require_witness_host)
+	@$(require_witness_log_lines)
 	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -b -m shell -a '\''printf "=== stdout ===\\n"; tail -n $(WITNESS_LOG_LINES) /var/log/keri/witness/stdout.log; printf "\\n=== stderr ===\\n"; tail -n $(WITNESS_LOG_LINES) /var/log/keri/witness/stderr.log'\'''

--- a/Makefile
+++ b/Makefile
@@ -29,30 +29,30 @@ witness-preflight: ## Validate 1Password-backed inventory values without opening
 
 .PHONY: witness-ping
 witness-ping: ## Check SSH connectivity to the configured witness host
-	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping'
 
 .PHONY: witness-check
 witness-check: ## Run preflight, ping, and bootstrap dry-run in one auth batch
-	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
 		$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping && \
 		$(ANSIBLE_PLAYBOOK) playbooks/witness-bootstrap.yml --check --diff'
 
 .PHONY: witness-apply
 witness-apply: ## Run preflight and apply the witness bootstrap in one auth batch
-	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
 		$(ANSIBLE_PLAYBOOK) playbooks/witness-bootstrap.yml'
 
 .PHONY: witness-verify
 witness-verify: ## Run the post-bootstrap witness verification playbook
-	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-verify.yml'
 
 .PHONY: witness-all
 witness-all: ## Run preflight, ping, apply, and verify in one auth batch
-	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
 		$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping && \
 		$(ANSIBLE_PLAYBOOK) playbooks/witness-bootstrap.yml && \
@@ -60,10 +60,10 @@ witness-all: ## Run preflight, ping, apply, and verify in one auth batch
 
 .PHONY: witness-status
 witness-status: ## Show systemd and Circus watcher status for the witness host
-	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -b -m shell -a '\''systemctl status circusd-witness --no-pager --lines=20; printf "\\n=== circusctl ===\\n"; /opt/keripy/.venv/bin/circusctl --endpoint ipc:///var/run/keri-circus/ctrl.sock status'\'''
 
 .PHONY: witness-logs
 witness-logs: ## Tail witness stdout and stderr logs from the host
-	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$(ONEPASSWORD_SSH_AUTH_SOCK)" "$(ANSIBLE_WRAPPER)" \
+	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -b -m shell -a '\''printf "=== stdout ===\\n"; tail -n $(WITNESS_LOG_LINES) /var/log/keri/witness/stdout.log; printf "\\n=== stderr ===\\n"; tail -n $(WITNESS_LOG_LINES) /var/log/keri/witness/stderr.log'\'''

--- a/deploy/ansible/.ansible-lint.yml
+++ b/deploy/ansible/.ansible-lint.yml
@@ -1,0 +1,8 @@
+---
+profile: production
+exclude_paths:
+  - .cache/
+warn_list:
+  - experimental
+offline: true
+use_default_rules: true

--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -1,0 +1,191 @@
+# Ansible Host-First Witness Deployment
+
+Ansible automation for deploying a KERI witness node using the host-first
+posture: Ansible prepares the host, Circus supervises the witness process,
+and systemd keeps `circusd` running across reboots.
+
+## Architecture
+
+```
+systemd
+  └── circusd-witness.service
+        └── circusd (Circus process manager)
+              └── keripy-witness watcher
+                    └── run-keripy-witness.sh  →  keri runWitness(...)
+```
+
+Ansible owns the machine state: packages, users, directories, Python venv,
+editable checkouts of `keripy` and `hio`, rendered configs, and the systemd
+unit. Circus owns the process lifecycle after the host is prepared.
+
+## Prerequisites
+
+- Ansible 2.14+ on the operator workstation
+- 1Password CLI (`op`) signed in to your account
+- `community.general` collection — install with:
+
+  ```bash
+  ansible-galaxy collection install community.general
+  ```
+
+### SSH Agent Setup
+
+> **Primary platform: macOS.** The operator workflow is designed and tested on
+> macOS using the native 1Password SSH agent. Linux is supported but is a
+> secondary target — see below.
+
+**macOS (primary)**
+
+1. In 1Password, go to **Settings → Developer → SSH Agent** and enable it.
+2. No further SSH config is needed. `with-op-ssh-agent.sh` falls back to the
+   standard macOS socket at
+   `~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`
+   automatically.
+
+**Linux**
+
+1. In 1Password, go to **Settings → Developer → SSH Agent** and enable it.
+2. The default socket path is `~/.1password/agent.sock`.
+   `with-op-ssh-agent.sh` falls back to this path automatically.
+3. If your setup uses a different agent (forwarded agent, `gnome-keyring`,
+   custom `ssh-agent`), export `SSH_AUTH_SOCK` before running any make
+   targets and the wrapper will use it as-is.
+4. The `ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT` environment variable can override
+   the detected socket path if your 1Password agent socket is in a
+   non-standard location.
+
+## First-Time Setup
+
+1. Copy the secret-reference template and fill in your 1Password references:
+
+   ```bash
+   cp op.env.example op.env
+   # edit op.env — replace YOUR_VAULT / YOUR_ITEM placeholders
+   ```
+
+   `op.env` is git-ignored. Never commit a filled-in `op.env`.
+
+2. Add a `host_vars/<your-host>.yml` following the pattern in
+   `inventories/pilot/host_vars/witness-do-01.yml`.
+
+3. Add the host to `inventories/pilot/hosts.yml` under `witness_hosts`.
+
+4. Review the defaults in `inventories/pilot/group_vars/witness_hosts.yml`
+   and override any values that differ for your environment.
+
+5. Run the preflight check:
+
+   ```bash
+   ./with-op-ssh-agent.sh --no-ssh-agent \
+     ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-preflight.yml
+   ```
+
+## Operator Workflow
+
+### From the repository root (recommended)
+
+```bash
+make witness-preflight   # validate 1Password env vars — no SSH needed
+make witness-check       # preflight + ping + bootstrap dry-run
+make witness-apply       # preflight + full bootstrap
+make witness-verify      # post-bootstrap validation
+make witness-status      # systemd + Circus status
+make witness-logs        # tail stdout and stderr logs
+```
+
+### Direct playbook invocation
+
+Run from this directory (`deploy/ansible/`):
+
+```bash
+# Validate inventory without opening SSH
+./with-op-ssh-agent.sh --no-ssh-agent \
+  ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-preflight.yml
+
+# Ping the host
+./with-op-ssh-agent.sh \
+  ansible -i inventories/pilot/hosts.yml witness-do-01 -m ping
+
+# Dry-run bootstrap
+./with-op-ssh-agent.sh \
+  ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-bootstrap.yml --check --diff
+
+# Apply bootstrap
+./with-op-ssh-agent.sh \
+  ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-bootstrap.yml
+
+# Verify
+./with-op-ssh-agent.sh \
+  ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-verify.yml
+```
+
+## Authentication
+
+SSH authentication uses the native 1Password SSH agent — no private keys are
+exported or copied. Controller-side variables (`ansible_user`, `ansible_host`,
+`ansible_become_password`) are injected as environment variables through a
+short-lived `op run` subprocess via `with-op-ssh-agent.sh`.
+
+The current validated escalation path on the pilot host is:
+
+1. SSH as the `keri` user (non-root)
+2. `su` to `root` with the separate root password from 1Password
+
+`sudo` is not assumed to be configured for the `keri` user.
+
+## Lint
+
+```bash
+ansible-lint playbooks/witness-bootstrap.yml \
+            playbooks/witness-preflight.yml \
+            playbooks/witness-verify.yml \
+            roles/witness_host
+```
+
+The checked-in `.ansible-lint.yml` uses the `production` profile in offline
+mode. Install the linter with `pipx install ansible-lint`.
+
+## Directory Layout
+
+```
+deploy/ansible/
+├── .ansible-lint.yml
+├── ansible.cfg
+├── op.env.example          # template for 1Password secret references
+├── README.md
+├── with-op-ssh-agent.sh    # op run + SSH agent wrapper
+├── inventories/
+│   └── pilot/
+│       ├── hosts.yml
+│       ├── group_vars/
+│       │   └── witness_hosts.yml   # shared defaults for all witness hosts
+│       └── host_vars/
+│           └── witness-do-01.yml   # pilot host overrides
+├── playbooks/
+│   ├── witness-preflight.yml   # inventory validation (no SSH)
+│   ├── witness-bootstrap.yml   # full host convergence
+│   └── witness-verify.yml      # post-bootstrap health checks
+└── roles/
+    └── witness_host/
+        ├── handlers/main.yml
+        ├── tasks/main.yml
+        └── templates/
+            ├── circus-witness.ini.j2
+            ├── circusd-witness.service.j2
+            └── run-keripy-witness.sh.j2
+```
+
+## What the Bootstrap Does
+
+1. Installs system packages: `git`, `rsync`, `build-essential`,
+   `libsodium-dev`, `python3.14`, `python3.14-venv`
+2. Creates the `keri` system user and group
+3. Creates directories: `/opt`, `/etc/keri`, `/usr/local/var/keri`,
+   `/var/log/keri/witness`
+4. Clones `keripy` (`/opt/keripy`) and `hio` (`/opt/hio`) from GitHub
+5. Creates a Python 3.14 venv at `/opt/keripy/.venv`
+6. Installs `circus` and editable installs of `hio` and `keripy` into the venv
+7. Renders `/opt/keripy/ops/run-keripy-witness.sh` from template
+8. Renders `/etc/keri/circus-witness.ini` from template (IPC-only control socket)
+9. Renders `/etc/systemd/system/circusd-witness.service` from template
+10. Enables and starts the `circusd-witness` systemd unit

--- a/deploy/ansible/ansible.cfg
+++ b/deploy/ansible/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+inventory = inventories/pilot/hosts.yml
+roles_path = roles
+interpreter_python = auto_silent
+retry_files_enabled = False
+
+[ssh_connection]
+pipelining = True

--- a/deploy/ansible/op.env.example
+++ b/deploy/ansible/op.env.example
@@ -1,0 +1,12 @@
+# Non-secret reference file for op run injection.
+# Copy this file to op.env and replace the placeholders with your own
+# 1Password secret references before running any Ansible commands.
+#
+# Format: op://VAULT_NAME/ITEM_NAME/FIELD_NAME
+# See: https://developer.1password.com/docs/cli/secret-references/
+#
+# The three variables below are injected at runtime by `op run` and are
+# never written to disk as plaintext. Do not commit a filled-in op.env.
+WITNESS_ANSIBLE_USER=op://YOUR_VAULT/YOUR_WITNESS_LOGIN_ITEM/username
+WITNESS_ANSIBLE_HOST=op://YOUR_VAULT/YOUR_WITNESS_LOGIN_ITEM/SSH/hostname
+WITNESS_ANSIBLE_BECOME_PASSWORD=op://YOUR_VAULT/YOUR_BECOME_PASSWORD_ITEM/password

--- a/deploy/ansible/with-op-ssh-agent.sh
+++ b/deploy/ansible/with-op-ssh-agent.sh
@@ -59,9 +59,12 @@ if ! command -v op >/dev/null 2>&1; then
     exit 1
 fi
 
-if ! command -v ssh-add >/dev/null 2>&1; then
-    echo "ssh-add is required" >&2
-    exit 1
+# Only require ssh-add when we are actually going to open an SSH connection.
+if [[ "$require_ssh_agent" -eq 1 ]]; then
+    if ! command -v ssh-add >/dev/null 2>&1; then
+        echo "ssh-add is required" >&2
+        exit 1
+    fi
 fi
 
 if [[ ! -f "$OP_RUN_ENV_FILE" ]]; then

--- a/deploy/ansible/with-op-ssh-agent.sh
+++ b/deploy/ansible/with-op-ssh-agent.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# with-op-ssh-agent.sh
+#
+# Primary platform: macOS
+#   SSH authentication uses the native 1Password SSH agent. The default socket
+#   path is the macOS-specific location set by the 1Password desktop app.
+#
+# Linux support:
+#   Also works on Linux if the 1Password SSH agent is running. The default
+#   socket path on Linux is ~/.1password/agent.sock. You can override the
+#   socket location by setting ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT in your
+#   environment before calling this script, or by pointing SSH_AUTH_SOCK at
+#   any already-running SSH agent that holds the correct key.
+#
+#   If you use a non-1Password SSH agent on Linux (e.g. ssh-agent, gnome-keyring,
+#   or a forwarded agent), export SSH_AUTH_SOCK before running this script and
+#   the agent-detection step will skip the 1Password socket lookup entirely.
+# -----------------------------------------------------------------------------
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OP_RUN_ENV_FILE="${OP_RUN_ENV_FILE:-${SCRIPT_DIR}/op.env}"
+
+# Resolve the default 1Password SSH agent socket for the current OS.
+# macOS: set by the 1Password desktop app under ~/Library/Group Containers/
+# Linux: set by the 1Password desktop app under ~/.1password/
+# Override by setting ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT in your environment.
+if [[ -z "${ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT:-}" ]]; then
+    case "$(uname -s)" in
+        Darwin)
+            ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+            ;;
+        Linux)
+            ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT="$HOME/.1password/agent.sock"
+            ;;
+        *)
+            ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT=""
+            ;;
+    esac
+fi
+
+require_ssh_agent=1
+
+if [[ ${1:-} == "--no-ssh-agent" ]]; then
+    require_ssh_agent=0
+    shift
+fi
+
+if [[ $# -eq 0 ]]; then
+    echo "usage: $0 [--no-ssh-agent] <ansible command> [args ...]" >&2
+    exit 1
+fi
+
+if ! command -v op >/dev/null 2>&1; then
+    echo "op CLI is required" >&2
+    exit 1
+fi
+
+if ! command -v ssh-add >/dev/null 2>&1; then
+    echo "ssh-add is required" >&2
+    exit 1
+fi
+
+if [[ ! -f "$OP_RUN_ENV_FILE" ]]; then
+    echo "op run env file is required: $OP_RUN_ENV_FILE" >&2
+    echo "Copy op.env.example to op.env and fill in your 1Password secret references." >&2
+    exit 1
+fi
+
+configure_1password_ssh_agent() {
+    # If SSH_AUTH_SOCK is already set and the agent has keys loaded, use it as-is.
+    # This covers: forwarded agents, gnome-keyring, custom macOS/Linux agents, etc.
+    if [[ -n ${SSH_AUTH_SOCK:-} ]] && ssh-add -l >/dev/null 2>&1; then
+        return 0
+    fi
+
+    # Try the platform-specific 1Password agent socket.
+    if [[ -n "${ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT:-}" ]] && [[ -S "$ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT" ]]; then
+        export SSH_AUTH_SOCK="$ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT"
+    fi
+
+    if [[ -z ${SSH_AUTH_SOCK:-} ]] || ! ssh-add -l >/dev/null 2>&1; then
+        cat >&2 <<'EOF'
+1Password SSH agent is not ready.
+
+macOS: Enable the SSH agent in 1Password Settings → Developer → SSH Agent.
+Linux: Enable the SSH agent in 1Password Settings → Developer → SSH Agent.
+        The default socket path is ~/.1password/agent.sock.
+
+Alternatively, export SSH_AUTH_SOCK pointing to any SSH agent that holds
+the correct key before calling this script.
+EOF
+        exit 1
+    fi
+}
+
+if [[ "$require_ssh_agent" -eq 1 ]]; then
+    configure_1password_ssh_agent
+fi
+
+exec op run --env-file="$OP_RUN_ENV_FILE" -- "$@"


### PR DESCRIPTION
Part 1 of 3 for the host-first witness deployment. See also:
- PR 2/3: inventory + playbooks (`feature/ansible-inventory-playbooks`)
- PR 3/3: `witness_host` role (`feature/ansible-role`)

---

## What this adds

The operator-facing surface: everything needed to understand and invoke the deployment, without the inventory specifics or role internals.

| File | Purpose |
|------|---------|
| `Makefile` | Root make targets: `witness-preflight`, `witness-check`, `witness-apply`, `witness-verify`, `witness-status`, `witness-logs` |
| `deploy/ansible/ansible.cfg` | Inventory path, roles path, SSH pipelining |
| `deploy/ansible/.ansible-lint.yml` | `production` profile, offline mode |
| `deploy/ansible/op.env.example` | Template for 1Password secret references — copy to `op.env` and fill in |
| `deploy/ansible/with-op-ssh-agent.sh` | Wraps any Ansible command with `op run` for secret injection and 1Password SSH agent setup |
| `deploy/ansible/README.md` | Operator guide: architecture diagram, per-OS SSH setup, first-time setup, full workflow |

## Authentication model

Primary platform is **macOS** using the native 1Password SSH agent. **Linux** is also supported — the wrapper auto-detects `~/.1password/agent.sock` or respects a pre-configured `SSH_AUTH_SOCK`. The `ONEPASSWORD_SSH_AUTH_SOCK_DEFAULT` env var overrides the socket path for non-standard setups.

Controller-side variables are injected through a short-lived `op run` subprocess — nothing is written to disk or exported into the shell.

## Quick start (after PRs 2 and 3 land)

```bash
cd deploy/ansible
cp op.env.example op.env   # fill in your 1Password references
ansible-galaxy collection install community.general
make witness-preflight     # validate — no SSH needed
make witness-apply         # full bootstrap
make witness-verify        # health check
```