### PR TITLE
feat(deploy): add Ansible inventory and playbooks [2/3]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,32 +53,16 @@ witness-ping: ## Check SSH connectivity to the configured witness host
 		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping'
 
 .PHONY: witness-check
-witness-check: ## Run preflight, ping, and bootstrap dry-run in one auth batch
+witness-check: ## Run preflight and ping in one auth batch
 	@$(require_witness_host)
 	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
-		$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping && \
-		$(ANSIBLE_PLAYBOOK) playbooks/witness-bootstrap.yml --check --diff'
-
-.PHONY: witness-apply
-witness-apply: ## Run preflight and apply the witness bootstrap in one auth batch
-	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
-		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
-		$(ANSIBLE_PLAYBOOK) playbooks/witness-bootstrap.yml'
+		$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping'
 
 .PHONY: witness-verify
 witness-verify: ## Run the post-bootstrap witness verification playbook
 	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
 		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-verify.yml'
-
-.PHONY: witness-all
-witness-all: ## Run preflight, ping, apply, and verify in one auth batch
-	@$(require_witness_host)
-	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
-		bash -lc '$(ANSIBLE_PLAYBOOK) playbooks/witness-preflight.yml && \
-		$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -m ping && \
-		$(ANSIBLE_PLAYBOOK) playbooks/witness-bootstrap.yml && \
-		$(ANSIBLE_PLAYBOOK) playbooks/witness-verify.yml'
 
 .PHONY: witness-status
 witness-status: ## Show systemd and Circus watcher status for the witness host

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,11 @@ ANSIBLE_INVENTORY := inventories/pilot/hosts.yml
 ANSIBLE_PLAYBOOK  := ansible-playbook -i $(ANSIBLE_INVENTORY)
 ANSIBLE_ADHOC     := ansible -i $(ANSIBLE_INVENTORY)
 ONEPASSWORD_SSH_AUTH_SOCK ?= $(HOME)/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock
-WITNESS_HOST      ?= witness-do-01
-WITNESS_LOG_LINES ?= 40
+WITNESS_HOST              ?= witness-do-01
+WITNESS_LOG_LINES         ?= 40
+WITNESS_SYSTEMD_SERVICE   ?= circusd-witness
+WITNESS_CIRCUSCTL_BIN     ?= /opt/keripy/.venv/bin/circusctl
+WITNESS_CIRCUS_ENDPOINT   ?= ipc:///var/run/keri-circus/ctrl.sock
 
 define require_witness_host
 [[ "$(WITNESS_HOST)" =~ ^[A-Za-z0-9_.-]+$$ ]] || { \
@@ -81,7 +84,7 @@ witness-all: ## Run preflight, ping, apply, and verify in one auth batch
 witness-status: ## Show systemd and Circus watcher status for the witness host
 	@$(require_witness_host)
 	@cd "$(ANSIBLE_DIR)" && SSH_AUTH_SOCK="$${SSH_AUTH_SOCK:-$(ONEPASSWORD_SSH_AUTH_SOCK)}" "$(ANSIBLE_WRAPPER)" \
-		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -b -m shell -a '\''systemctl status circusd-witness --no-pager --lines=20; printf "\\n=== circusctl ===\\n"; /opt/keripy/.venv/bin/circusctl --endpoint ipc:///var/run/keri-circus/ctrl.sock status'\'''
+		bash -lc '$(ANSIBLE_ADHOC) "$(WITNESS_HOST)" -b -m shell -a '\''systemctl status $(WITNESS_SYSTEMD_SERVICE) --no-pager --lines=20; printf "\\n=== circusctl ===\\n"; $(WITNESS_CIRCUSCTL_BIN) --endpoint $(WITNESS_CIRCUS_ENDPOINT) status'\'''
 
 .PHONY: witness-logs
 witness-logs: ## Tail witness stdout and stderr logs from the host

--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -1,22 +1,25 @@
-# Ansible Host-First Witness Deployment
+# Ansible Host-First Witness Inventory And Verification
 
-Ansible automation for deploying a KERI witness node using the host-first
-posture: Ansible prepares the host, Circus supervises the witness process,
-and systemd keeps `circusd` running across reboots.
+This directory currently owns the pilot inventory, controller-side preflight,
+host verification playbooks, and operator inspection commands for the
+host-first witness deployment.
 
-## Architecture
+It does not yet own full host convergence. Bootstrap automation and the
+`witness_host` role are introduced separately so this layer can remain valid
+on its own.
+
+## Scope
 
 ```
-systemd
-  └── circusd-witness.service
-        └── circusd (Circus process manager)
-              └── keripy-witness watcher
-                    └── run-keripy-witness.sh  →  keri runWitness(...)
+controller
+  ├── pilot inventory
+  ├── preflight assertions
+  ├── verification playbook
+  └── operator inspection commands
 ```
 
-Ansible owns the machine state: packages, users, directories, Python venv,
-editable checkouts of `keripy` and `hio`, rendered configs, and the systemd
-unit. Circus owns the process lifecycle after the host is prepared.
+This layer validates controller inputs, proves the current host state, and
+exposes inspection commands for an already bootstrapped witness host.
 
 ## Prerequisites
 
@@ -86,9 +89,8 @@ unit. Circus owns the process lifecycle after the host is prepared.
 
 ```bash
 make witness-preflight   # validate 1Password env vars — no SSH needed
-make witness-check       # preflight + ping + bootstrap dry-run
-make witness-apply       # preflight + full bootstrap
-make witness-verify      # post-bootstrap validation
+make witness-check       # preflight + ping
+make witness-verify      # post-bootstrap validation for an existing host
 make witness-status      # systemd + Circus status
 make witness-logs        # tail stdout and stderr logs
 ```
@@ -106,15 +108,7 @@ Run from this directory (`deploy/ansible/`):
 ./with-op-ssh-agent.sh \
   ansible -i inventories/pilot/hosts.yml witness-do-01 -m ping
 
-# Dry-run bootstrap
-./with-op-ssh-agent.sh \
-  ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-bootstrap.yml --check --diff
-
-# Apply bootstrap
-./with-op-ssh-agent.sh \
-  ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-bootstrap.yml
-
-# Verify
+# Verify an already bootstrapped host
 ./with-op-ssh-agent.sh \
   ansible-playbook -i inventories/pilot/hosts.yml playbooks/witness-verify.yml
 ```
@@ -136,10 +130,8 @@ The current validated escalation path on the pilot host is:
 ## Lint
 
 ```bash
-ansible-lint playbooks/witness-bootstrap.yml \
-            playbooks/witness-preflight.yml \
-            playbooks/witness-verify.yml \
-            roles/witness_host
+ansible-lint playbooks/witness-preflight.yml \
+            playbooks/witness-verify.yml
 ```
 
 The checked-in `.ansible-lint.yml` uses the `production` profile in offline
@@ -163,29 +155,5 @@ deploy/ansible/
 │           └── witness-do-01.yml   # pilot host overrides
 ├── playbooks/
 │   ├── witness-preflight.yml   # inventory validation (no SSH)
-│   ├── witness-bootstrap.yml   # full host convergence
 │   └── witness-verify.yml      # post-bootstrap health checks
-└── roles/
-    └── witness_host/
-        ├── handlers/main.yml
-        ├── tasks/main.yml
-        └── templates/
-            ├── circus-witness.ini.j2
-            ├── circusd-witness.service.j2
-            └── run-keripy-witness.sh.j2
 ```
-
-## What the Bootstrap Does
-
-1. Installs system packages: `git`, `rsync`, `build-essential`,
-   `libsodium-dev`, `python3.14`, `python3.14-venv`
-2. Creates the `keri` system user and group
-3. Creates directories: `/opt`, `/etc/keri`, `/usr/local/var/keri`,
-   `/var/log/keri/witness`
-4. Clones `keripy` (`/opt/keripy`) and `hio` (`/opt/hio`) from GitHub
-5. Creates a Python 3.14 venv at `/opt/keripy/.venv`
-6. Installs `circus` and editable installs of `hio` and `keripy` into the venv
-7. Renders `/opt/keripy/ops/run-keripy-witness.sh` from template
-8. Renders `/etc/keri/circus-witness.ini` from template (IPC-only control socket)
-9. Renders `/etc/systemd/system/circusd-witness.service` from template
-10. Enables and starts the `circusd-witness` systemd unit

--- a/deploy/ansible/inventories/pilot/group_vars/witness_hosts.yml
+++ b/deploy/ansible/inventories/pilot/group_vars/witness_hosts.yml
@@ -1,0 +1,87 @@
+witness_service_user: keri
+witness_service_group: keri
+witness_service_shell: /bin/bash
+witness_systemd_service_name: circusd-witness
+
+witness_repo_parent_dir: /opt
+witness_keripy_home: /opt/keripy
+witness_hio_home: /opt/hio
+witness_keri_config_dir: /etc/keri
+witness_circus_config_path: /etc/keri/circus-witness.ini
+witness_service_unit_path: /etc/systemd/system/circusd-witness.service
+witness_keri_data_dir: /usr/local/var/keri
+witness_runtime_dir: /var/run/keri-circus
+witness_log_dir: /var/log/keri/witness
+witness_stdout_log_path: /var/log/keri/witness/stdout.log
+witness_stderr_log_path: /var/log/keri/witness/stderr.log
+witness_wrapper_path: /opt/keripy/ops/run-keripy-witness.sh
+witness_venv_path: /opt/keripy/.venv
+
+witness_shell_bin: /bin/bash
+witness_python_bootstrap_bin: python3.14
+witness_python_bin: /opt/keripy/.venv/bin/python
+witness_pip_executable: /opt/keripy/.venv/bin/pip
+witness_circusd_bin: /opt/keripy/.venv/bin/circusd
+witness_circusctl_bin: /opt/keripy/.venv/bin/circusctl
+
+witness_circus_endpoint: ipc:///var/run/keri-circus/ctrl.sock
+witness_circus_pubsub_endpoint: ipc:///var/run/keri-circus/pub.sock
+witness_circus_stats_endpoint: ipc:///var/run/keri-circus/stats.sock
+witness_circus_statsd: 0
+witness_stop_signal: TERM
+witness_graceful_timeout: 30
+
+witness_system_packages:
+  - git
+  - rsync
+  - build-essential
+  - libsodium-dev
+  - python3.14
+  - python3.14-venv
+  - python3-pip
+
+witness_python_packages:
+  - circus
+
+witness_checkout_mode: source
+witness_keripy_repo_url: https://github.com/WebOfTrust/keripy
+witness_hio_repo_url: https://github.com/ioflo/hio
+
+witness_directories:
+  - path: "{{ witness_repo_parent_dir }}"
+    owner: root
+    group: root
+    mode: "0755"
+  - path: "{{ witness_keri_config_dir }}"
+    owner: root
+    group: "{{ witness_service_group }}"
+    mode: "0750"
+  - path: "{{ witness_log_dir }}"
+    owner: "{{ witness_service_user }}"
+    group: "{{ witness_service_group }}"
+    mode: "0750"
+  - path: "{{ witness_keri_data_dir }}"
+    owner: "{{ witness_service_user }}"
+    group: "{{ witness_service_group }}"
+    mode: "0750"
+
+witness_git_checkouts:
+  - repo: "{{ witness_hio_repo_url }}"
+    name: hio
+    dest: "{{ witness_hio_home }}"
+    version: "{{ witness_hio_repo_version }}"
+  - repo: "{{ witness_keripy_repo_url }}"
+    name: keripy
+    dest: "{{ witness_keripy_home }}"
+    version: "{{ witness_keripy_repo_version }}"
+
+witness_editable_python_paths:
+  - "{{ witness_hio_home }}"
+  - "{{ witness_keripy_home }}"
+
+witness_required_host_vars:
+  - witness_name
+  - witness_base
+  - witness_alias
+  - witness_http_port
+  - witness_tcp_port

--- a/deploy/ansible/inventories/pilot/group_vars/witness_hosts.yml
+++ b/deploy/ansible/inventories/pilot/group_vars/witness_hosts.yml
@@ -85,3 +85,6 @@ witness_required_host_vars:
   - witness_alias
   - witness_http_port
   - witness_tcp_port
+  - witness_expire
+  - witness_keripy_repo_version
+  - witness_hio_repo_version

--- a/deploy/ansible/inventories/pilot/host_vars/witness-do-01.yml
+++ b/deploy/ansible/inventories/pilot/host_vars/witness-do-01.yml
@@ -1,0 +1,24 @@
+ansible_user: >-
+  {{
+    lookup('ansible.builtin.env', 'WITNESS_ANSIBLE_USER', default='') | trim
+  }}
+ansible_host: >-
+  {{
+    lookup('ansible.builtin.env', 'WITNESS_ANSIBLE_HOST', default='') | trim | regex_replace('^.*@', '')
+  }}
+ansible_become_method: su
+ansible_become_user: root
+ansible_become_password: >-
+  {{
+    lookup('ansible.builtin.env', 'WITNESS_ANSIBLE_BECOME_PASSWORD', default='') | trim
+  }}
+
+witness_name: witness-do-01
+witness_base: witness-do-01
+witness_alias: witness-do-01
+witness_http_port: 5631
+witness_tcp_port: 5632
+witness_expire: 0.0
+
+witness_keripy_repo_version: main
+witness_hio_repo_version: main

--- a/deploy/ansible/inventories/pilot/hosts.yml
+++ b/deploy/ansible/inventories/pilot/hosts.yml
@@ -1,0 +1,5 @@
+all:
+  children:
+    witness_hosts:
+      hosts:
+        witness-do-01:

--- a/deploy/ansible/playbooks/witness-bootstrap.yml
+++ b/deploy/ansible/playbooks/witness-bootstrap.yml
@@ -1,8 +1,0 @@
----
-- name: Bootstrap host-first witness pilot
-  hosts: witness_hosts
-  become: true
-  gather_facts: true
-
-  roles:
-    - witness_host

--- a/deploy/ansible/playbooks/witness-bootstrap.yml
+++ b/deploy/ansible/playbooks/witness-bootstrap.yml
@@ -1,0 +1,8 @@
+---
+- name: Bootstrap host-first witness pilot
+  hosts: witness_hosts
+  become: true
+  gather_facts: true
+
+  roles:
+    - witness_host

--- a/deploy/ansible/playbooks/witness-preflight.yml
+++ b/deploy/ansible/playbooks/witness-preflight.yml
@@ -1,0 +1,59 @@
+---
+- name: Preflight host-first witness pilot
+  hosts: witness_hosts
+  become: false
+  gather_facts: false
+
+  tasks:
+    - name: Assert pilot inventory resolves a host address
+      ansible.builtin.assert:
+        that:
+          - ansible_host is defined
+          - ansible_host | string | length > 0
+        fail_msg: Resolve ansible_host from 1Password before running the pilot
+
+    - name: Assert pilot inventory uses the non-root keri login
+      ansible.builtin.assert:
+        that:
+          - ansible_user is defined
+          - ansible_user == 'keri'
+        fail_msg: The pilot must use the keri user instead of root
+
+    - name: Assert controller env resolves witness user from op run
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.env', 'WITNESS_ANSIBLE_USER', default='') | string | length > 0
+        fail_msg: Resolve WITNESS_ANSIBLE_USER through op run before running the pilot
+
+    - name: Assert controller env resolves witness host from op run
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.env', 'WITNESS_ANSIBLE_HOST', default='') | string | length > 0
+        fail_msg: Resolve WITNESS_ANSIBLE_HOST through op run before running the pilot
+
+    - name: Assert become password resolves from op run
+      ansible.builtin.assert:
+        that:
+          - ansible_become_password is defined
+          - ansible_become_password | string | length > 0
+        fail_msg: Resolve WITNESS_ANSIBLE_BECOME_PASSWORD through op run before running the pilot
+
+    - name: Assert become method stays on the validated host path
+      ansible.builtin.assert:
+        that:
+          - ansible_become_method == 'su'
+          - ansible_become_user == 'root'
+        fail_msg: The current validated host escalation path is keri SSH plus su to root
+
+    - name: Assert required witness variables are present
+      ansible.builtin.assert:
+        that:
+          - lookup('vars', item, default='') | string | length > 0
+        fail_msg: "Required pilot variable is missing: {{ item }}"
+      loop: "{{ witness_required_host_vars }}"
+
+    - name: Assert host ports are distinct
+      ansible.builtin.assert:
+        that:
+          - witness_http_port | int != witness_tcp_port | int
+        fail_msg: witness_http_port and witness_tcp_port must be different

--- a/deploy/ansible/playbooks/witness-verify.yml
+++ b/deploy/ansible/playbooks/witness-verify.yml
@@ -1,0 +1,165 @@
+---
+- name: Verify host-first witness pilot
+  hosts: witness_hosts
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert witness service is running and enabled
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services[witness_systemd_service_name + '.service'] is defined
+          - ansible_facts.services[witness_systemd_service_name + '.service'].state == 'running'
+          - ansible_facts.services[witness_systemd_service_name + '.service'].status == 'enabled'
+        fail_msg: "{{ witness_systemd_service_name }} is not enabled and running"
+
+    - name: Check IPC control socket
+      ansible.builtin.stat:
+        path: "{{ witness_runtime_dir }}/ctrl.sock"
+      register: witness_ctrl_socket
+
+    - name: Check witness stdout log
+      ansible.builtin.stat:
+        path: "{{ witness_stdout_log_path }}"
+      register: witness_stdout_log
+
+    - name: Check witness stderr log
+      ansible.builtin.stat:
+        path: "{{ witness_stderr_log_path }}"
+      register: witness_stderr_log
+
+    - name: Assert sockets and log files exist
+      ansible.builtin.assert:
+        that:
+          - witness_ctrl_socket.stat.exists
+          - witness_ctrl_socket.stat.issock | default(false)
+          - witness_stdout_log.stat.exists
+          - witness_stderr_log.stat.exists
+        fail_msg: Witness IPC socket or log files are missing
+
+    - name: Query Circus watcher status
+      ansible.builtin.command:
+        argv:
+          - "{{ witness_circusctl_bin }}"
+          - --endpoint
+          - "{{ witness_circus_endpoint }}"
+          - status
+      register: witness_circus_status
+      changed_when: false
+
+    - name: Assert watcher is present in Circus status output
+      ansible.builtin.assert:
+        that:
+          - "'keripy-witness' in witness_circus_status.stdout"
+        fail_msg: Circus status did not report the keripy-witness watcher
+
+    - name: Read systemd main PID for Circus
+      ansible.builtin.command:
+        argv:
+          - systemctl
+          - show
+          - -p
+          - MainPID
+          - --value
+          - "{{ witness_systemd_service_name }}"
+      register: witness_systemd_main_pid
+      changed_when: false
+
+    - name: Assert Circus main PID exists
+      ansible.builtin.assert:
+        that:
+          - (witness_systemd_main_pid.stdout | trim | int) > 0
+        fail_msg: systemd did not report a valid MainPID for {{ witness_systemd_service_name }}
+
+    - name: Sample non-stats watcher child process
+      ansible.builtin.command:
+        argv:
+          - ps
+          - -ww
+          - --ppid
+          - "{{ witness_systemd_main_pid.stdout | trim }}"
+          - -o
+          - pid=,stat=,args=
+      register: witness_child_sample_1
+      changed_when: false
+
+    - name: Filter first watcher child sample
+      ansible.builtin.set_fact:
+        witness_child_sample_1_lines: >-
+          {{
+            witness_child_sample_1.stdout_lines
+            | reject('search', 'circus import stats')
+            | list
+          }}
+
+    - name: Assert first watcher child sample is present
+      ansible.builtin.assert:
+        that:
+          - witness_child_sample_1_lines | length == 1
+        fail_msg: Expected exactly one non-stats watcher child under Circus
+
+    - name: Pause before second watcher child sample
+      ansible.builtin.pause:
+        seconds: 2
+
+    - name: Sample non-stats watcher child process again
+      ansible.builtin.command:
+        argv:
+          - ps
+          - -ww
+          - --ppid
+          - "{{ witness_systemd_main_pid.stdout | trim }}"
+          - -o
+          - pid=,stat=,args=
+      register: witness_child_sample_2
+      changed_when: false
+
+    - name: Filter second watcher child sample
+      ansible.builtin.set_fact:
+        witness_child_sample_2_lines: >-
+          {{
+            witness_child_sample_2.stdout_lines
+            | reject('search', 'circus import stats')
+            | list
+          }}
+
+    - name: Assert second watcher child sample is present
+      ansible.builtin.assert:
+        that:
+          - witness_child_sample_2_lines | length == 1
+        fail_msg: Expected exactly one non-stats watcher child under Circus on second sample
+
+    - name: Parse watcher child samples
+      ansible.builtin.set_fact:
+        witness_child_parts_1: "{{ (witness_child_sample_1_lines | first).split() }}"
+        witness_child_parts_2: "{{ (witness_child_sample_2_lines | first).split() }}"
+
+    - name: Wait for witness HTTP listener
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: "{{ witness_http_port }}"
+        state: started
+        timeout: 3
+        connect_timeout: 1
+
+    - name: Wait for witness TCP listener
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: "{{ witness_tcp_port }}"
+        state: started
+        timeout: 3
+        connect_timeout: 1
+
+    - name: Assert witness runtime stays alive and binds expected ports
+      ansible.builtin.assert:
+        that:
+          - witness_child_parts_1[0] == witness_child_parts_2[0]
+          - witness_child_parts_1[1] is not search('Z')
+          - witness_child_parts_2[1] is not search('Z')
+        fail_msg: |
+          Witness runtime is unhealthy.
+          sample_1={{ witness_child_sample_1_lines | first }}
+          sample_2={{ witness_child_sample_2_lines | first }}


### PR DESCRIPTION
Part 2 of 3 for the host-first witness deployment.

**Merge order: #9 first, then this PR, then PR 3/3.**

See also:
- PR 1/3: operator surface (#9) - merge first
- PR 3/3: `witness_host` role (`feature/ansible-role`) - merge last

---

## What this PR owns by itself

This PR is the standalone inventory, preflight, verification, and inspection layer.

It is intentionally merge-safe without PR 3/3.

### Inventory (`inventories/pilot/`)

| File | Purpose |
|------|---------|
| `hosts.yml` | Single `witness_hosts` group containing `witness-do-01` |
| `group_vars/witness_hosts.yml` | Shared defaults for all witness hosts: paths, venv locations, Circus IPC endpoints, system packages, and required inventory values |
| `host_vars/witness-do-01.yml` | Pilot host overrides - `ansible_user`, `ansible_host`, and `ansible_become_password` resolved at runtime via `op run`; no secrets in checked-in files |

### Playbooks and operator surface

| Surface | Purpose |
|---------|---------|
| `witness-preflight.yml` | Controller-side validation only, no SSH. Asserts `op run` env vars resolve, become method is `su`, required host vars are present, and HTTP/TCP ports are distinct. |
| `witness-verify.yml` | Post-bootstrap health checks for an already bootstrapped host: systemd service state, IPC control socket, Circus watcher present, stable PID across two samples 2 s apart, and port listeners on both HTTP and TCP ports. |
| `make witness-check` | Preflight + ping only |
| `make witness-status` | systemd + Circus inspection |
| `make witness-logs` | stdout/stderr inspection |

## What is intentionally deferred to PR 3/3

This PR does **not** own host convergence.

The following stay in PR 3/3 so this parent PR remains independently merge-safe:

- `witness-bootstrap.yml`
- `witness_host` role implementation
- `make witness-apply`
- bootstrap dry-run/apply/all workflows that depend on the role

## Escalation path

The current validated path on the pilot host is SSH as `keri` + `su` to `root`. This is asserted in `witness-preflight.yml`; `sudo` is not assumed.

## Validation

- `ansible-lint playbooks/witness-preflight.yml playbooks/witness-verify.yml`
- `make -n witness-check witness-verify witness-status witness-logs`

## Why this boundary changed

The branch was restacked so PR 10 no longer introduces commands or docs that depend on the child role PR. This makes the parent PR independently reviewable and merge-safe.