### PR TITLE
Handle port 443 for oobi url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,7 +173,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Abstra
 # Abstra is an AI-powered process automation framework.

--- a/src/witopnet/app/aiding.py
+++ b/src/witopnet/app/aiding.py
@@ -162,9 +162,11 @@ class AidCollectionEnd:
             else urls[kering.Schemes.https]
         )
         up = urlparse(url)
-        oobi = (
-            f"{up.scheme}://{up.hostname}:{up.port}/oobi/{witness.hab.pre}/controller"
-        )
+        if up.port is None:
+            endpoint = f"{up.scheme}://{up.hostname}"
+        else:
+            endpoint = f"{up.scheme}://{up.hostname}:{up.port}"
+        oobi = f"{endpoint}/oobi/{witness.hab.pre}/controller"
 
         body = dict(totp=cipher.qb64, oobi=oobi)
 


### PR DESCRIPTION
In witnessery the witopnet.curls are read in, and if the ports are 443 or 80 (defaults), the port is set to None.  Then later, when trying to build the oobi URL in aiding.py, we're explicitly including the port, which ends up being None, so you get an oobi URL like https://someurl:None/oobi/...