### PR TITLE
updating witnesses for full stack communication

### DIFF
--- a/src/witopnet/core/oobing.py
+++ b/src/witopnet/core/oobing.py
@@ -71,12 +71,6 @@ class OOBIEnd:
         if not db.fullyWitnessed(kever.serder):
             raise falcon.HTTPNotFound(description=f"aid {aid} not found")
 
-        replying = dict(
-            version=kering.Vrsn_1_0,
-            pvrsn=kering.Vrsn_1_0,
-            kind=eventing.Kinds.json,
-        )
-
         owits = oset(kever.wits)
         if kever.prefixer.qb64 in witness.hby.prefixes:  # One of our identifiers
             hab = witness.hby.habs[kever.prefixer.qb64]
@@ -87,6 +81,14 @@ class OOBIEnd:
             hab = witness.hby.habs[pre]
         else:  # Not allowed to respond
             raise falcon.HTTPNotAcceptable(description="invalid OOBI request")
+
+        pvrsn = hab.kever.serder.pvrsn
+        gvrsn = pvrsn
+        replying = dict(
+            pvrsn=pvrsn,
+            gvrsn=gvrsn,
+            kind=eventing.Kinds.json,
+        )
 
         eids = []
         if eid:
@@ -105,7 +107,7 @@ class OOBIEnd:
                 eids=eids,
                 **replying,
             )
-            msgs.extend(hab.replay(aid))
+            msgs.extend(hab.replay(aid, gvrsn=gvrsn))
 
         if msgs:
             rep.status = falcon.HTTP_200  # This is the default status

--- a/src/witopnet/core/witnessing.py
+++ b/src/witopnet/core/witnessing.py
@@ -404,6 +404,7 @@ class Witnessery(doing.DoDoer):
                 role=kering.Roles.controller,
                 stamp=dt,
                 version=kering.Vrsn_2_0,
+                kind=eventing.Kinds.json,
             )
         )
         msgs.extend(
@@ -412,6 +413,7 @@ class Witnessery(doing.DoDoer):
                 scheme=self.scheme,
                 stamp=dt,
                 version=kering.Vrsn_2_0,
+                kind=eventing.Kinds.json,
             )
         )
         hab.psr.parse(ims=msgs)

--- a/tests/witopnet/app/test_aiding.py
+++ b/tests/witopnet/app/test_aiding.py
@@ -9,6 +9,7 @@ import json
 import falcon
 
 import pyotp
+import pytest
 from falcon import testing
 from hio.base import doing
 from keri import kering
@@ -18,7 +19,7 @@ from keri.app.httping import (
     CESR_CONTENT_TYPE,
     CESR_DESTINATION_HEADER,
 )
-from keri.core import coring, serdering, counting
+from keri.core import coring, serdering, counting, eventing
 from keri.help import helping
 
 from witopnet.app import aiding, indirecting
@@ -112,16 +113,27 @@ def _start_witery(hab):
     return doist, witery
 
 
-def test_aids_uses_message_protocol_version(multipart):
-    """Regression: KERI10 CESR attachments must parse with the event's pvrsn.
-
-    Newer keripy defaults attachment decoding to CESR v2 unless ``version=`` is
-    supplied; without matching v1, controller sigs are dropped and /aids returns
-    ``KEL part not valid inception event``.
-    """
+@pytest.mark.parametrize(
+    "version",
+    (kering.Vrsn_1_0, kering.Vrsn_2_0),
+    ids=("v1", "v2"),
+)
+def test_aids_uses_message_protocol_version(multipart, version):
+    """Regression: /aids must parse attachments with the event's pvrsn."""
     with (
-        habbing.openHab(name="bob", salt=b"0123456789fedbob") as (_, bobHab),
-        habbing.openHab(name="wan", transferable=False, salt=b"0123456789fedcba") as (
+        habbing.openHab(
+            name=f"bob-aids-v{version.major}",
+            salt=b"0123456789fedbob",
+            version=version,
+            kind=eventing.Kinds.json,
+        ) as (_, bobHab),
+        habbing.openHab(
+            name="wan",
+            transferable=False,
+            salt=b"0123456789fedcba",
+            version=kering.Vrsn_2_0,
+            kind=eventing.Kinds.json,
+        ) as (
             _,
             wanHab,
         ),
@@ -147,7 +159,8 @@ def test_aids_uses_message_protocol_version(multipart):
 
         kel = bobHab.msgOwnEvent(sn=0)
         serder = serdering.SerderKERI(raw=kel)
-        assert kering.deversify(serder.ked["v"]).pvrsn.major == 1
+        assert serder.pvrsn == version
+        assert serder.kind == eventing.Kinds.json
 
         body, headers = multipart.create(dict(kel=kel))
         headers[CESR_DESTINATION_HEADER] = bob_wit
@@ -167,7 +180,12 @@ def test_http_post_uses_inbound_version_across_event_types():
 
     for bob_name, bob_salt, version in cases:
         with (
-            habbing.openHab(name=bob_name, salt=bob_salt, version=version) as (
+            habbing.openHab(
+                name=bob_name,
+                salt=bob_salt,
+                version=version,
+                kind=eventing.Kinds.json,
+            ) as (
                 _,
                 bobHab,
             ),
@@ -176,6 +194,7 @@ def test_http_post_uses_inbound_version_across_event_types():
                 transferable=False,
                 salt=b"0123456789fehtwa",
                 version=kering.Vrsn_2_0,
+                kind=eventing.Kinds.json,
             ) as (_, wanHab),
         ):
             _seed_endpoint_records(
@@ -226,6 +245,7 @@ def test_http_post_uses_inbound_version_across_event_types():
                 src=bob_wit,
                 route="ksn",
                 version=version,
+                kind=eventing.Kinds.json,
             )
             req = _create_cesr_request(
                 path="/",
@@ -243,6 +263,7 @@ def test_http_post_uses_inbound_version_across_event_types():
                 eid=bobHab.pre,
                 role=kering.Roles.controller,
                 version=version,
+                kind=eventing.Kinds.json,
             )
             req = _create_cesr_request(
                 path="/",
@@ -259,14 +280,30 @@ def test_http_post_uses_inbound_version_across_event_types():
 
 def test_encrypting_totp(multipart):
     with (
-        habbing.openHab(name="bob", salt=b"0123456789fedbob") as (bobHby, bobHab),
-        habbing.openHab(name="eve", salt=b"0123456789fedeve") as (eveHby, eveHab),
-        habbing.openHab(name="wan", transferable=False, salt=b"0123456789fedcba") as (
+        habbing.openHab(
+            name="bob",
+            salt=b"0123456789fedbob",
+            version=kering.Vrsn_2_0,
+            kind=eventing.Kinds.json,
+        ) as (bobHby, bobHab),
+        habbing.openHab(
+            name="eve",
+            salt=b"0123456789fedeve",
+            version=kering.Vrsn_2_0,
+            kind=eventing.Kinds.json,
+        ) as (eveHby, eveHab),
+        habbing.openHab(
+            name="wan",
+            transferable=False,
+            salt=b"0123456789fedcba",
+            version=kering.Vrsn_2_0,
+            kind=eventing.Kinds.json,
+        ) as (
             wanHby,
             wanHab,
         ),
     ):
-        assert bobHab.pre == "ENsqL5zLYNbZf0kcOlx-ioqNWlatD9rKZZM4hbEI7nza"
+        assert bobHab.pre == "EO5CgjiI4SVOuVNj-C5a0k-seIvFDuswAm_dwj5kVJzB"
         verfer = bobHab.kever.verfers[0]
         assert verfer.qb64 == "DIJUDTxA5U1aX0XkaX4_Sx6dBYEfZcIWynOmeXsDFeQP"
 
@@ -378,7 +415,7 @@ def test_encrypting_totp(multipart):
 
         assert rep.status == falcon.HTTP_PRECONDITION_FAILED
         assert rep.json == {
-            "description": "AID=ENsqL5zLYNbZf0kcOlx-ioqNWlatD9rKZZM4hbEI7nza not "
+            "description": "AID=EO5CgjiI4SVOuVNj-C5a0k-seIvFDuswAm_dwj5kVJzB not "
             "initialized with 2-factor code",
             "title": "412 Precondition Failed",
         }
@@ -419,7 +456,11 @@ def test_encrypting_totp(multipart):
         totp = pyotp.TOTP(rcode)
         assert totp is not None
 
-        rot = bobHab.rotate(adds=[bobWit])
+        rot = bobHab.rotate(
+            adds=[bobWit],
+            version=kering.Vrsn_2_0,
+            gvrsn=kering.Vrsn_2_0,
+        )
 
         serder = serdering.SerderKERI(raw=rot)
         act = rot[serder.size :]
@@ -452,11 +493,11 @@ def test_encrypting_totp(multipart):
         assert rct.ked["t"] == "rct"
         assert rct.sn == 1
         assert rct.pre == bobHab.pre
-        assert kering.deversify(rct.ked["v"]).pvrsn.major == 1
+        assert rct.pvrsn == kering.Vrsn_2_0
 
         # Fetch the same stored receipt back over GET and verify that receipt
-        # lookup stays on the stored event's v1 body version while framing any
-        # generated witness signatures in the modern v2 CESR attachment format.
+        # lookup stays on the stored event's v2 body version while framing the
+        # generated witness signatures in the v2 CESR attachment format.
         rep = client.simulate_get(
             "/receipts",
             query_string=f"pre={bobHab.pre}&sn=1",
@@ -464,7 +505,7 @@ def test_encrypting_totp(multipart):
         )
         assert rep.status == falcon.HTTP_200
         rct = serdering.SerderKERI(raw=rep.content)
-        assert kering.deversify(rct.ked["v"]).pvrsn.major == 1
+        assert rct.pvrsn == kering.Vrsn_2_0
         atc = rep.content[len(rct.raw) :]
         assert counting.Counter(qb64b=atc).code == counting.CtrDex_2_0.WitnessIdxSigs
 
@@ -473,13 +514,17 @@ def test_receipts_post_and_get_follow_stored_v2_event_version(multipart):
     """Receipts should keep a v2 event's body version on both POST and GET."""
     with (
         habbing.openHab(
-            name="bob-v2", salt=b"0123456789febob2", version=kering.Vrsn_2_0
+            name="bob-v2",
+            salt=b"0123456789febob2",
+            version=kering.Vrsn_2_0,
+            kind=eventing.Kinds.json,
         ) as (_, bobHab),
         habbing.openHab(
             name="wan-v2",
             transferable=False,
             salt=b"0123456789fecba2",
             version=kering.Vrsn_2_0,
+            kind=eventing.Kinds.json,
         ) as (_, wanHab),
     ):
         _seed_endpoint_records(

--- a/tests/witopnet/app/test_witnessing.py
+++ b/tests/witopnet/app/test_witnessing.py
@@ -6,7 +6,6 @@ tests.app.test_witnessing module
 
 import errno
 import json
-import re
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -15,28 +14,20 @@ from falcon import testing
 from hio.base import doing
 from keri import kering
 from keri.app import habbing
+from keri.core import eventing, parsing
 from keri.help import helping
 
 from witopnet.core import basing, oobing, witnessing
 
 CONTROLLER_AID = "ENsqL5zLYNbZf0kcOlx-ioqNWlatD9rKZZM4hbEI7nza"
-STREAM_MESSAGE_PATTERN = re.compile(rb'\{"v":"([^"]+)","t":"([^"]+)"')
 
 
 def _stream_messages(stream):
-    """Return `(version, ilk)` pairs for each JSON KERI message in a CESR stream.
-
-    OOBI responses concatenate JSON KERI bodies with CESR attachments, so this
-    helper inspects each serialized body directly instead of assuming the first
-    message tells the whole versioning story for the stream.
-    """
-    messages = []
-    for version, ilk in STREAM_MESSAGE_PATTERN.findall(stream):
-        messages.append(
-            (kering.deversify(version.decode("utf-8")).pvrsn, ilk.decode("utf-8"))
-        )
-
-    return messages
+    """Parse every KERI message and its CESR attachments from an OOBI stream."""
+    ims = bytearray(stream)
+    results = parsing.Parser().parse(ims=ims, framed=False, processive=False)
+    assert not ims
+    return results
 
 
 def test_delete_witness_removes_registry_before_closing():
@@ -144,6 +135,7 @@ def test_self_owned_oobi_reuses_stored_reply_record_versions():
         transferable=False,
         salt=b"0123456789fedoob",
         version=kering.Vrsn_2_0,
+        kind=eventing.Kinds.json,
     ) as (_, wanHab):
         url = "http://127.0.0.1:5642/"
         msgs = bytearray()
@@ -189,19 +181,50 @@ def test_self_owned_oobi_reuses_stored_reply_record_versions():
         )
         assert rep_w.status == falcon.HTTP_OK
         witness_aid = rep_w.json["eid"]
+        witness = witery.wits[witness_aid]
 
         # Fetch the OOBI and assert it is successful and parse the messages
-        response = client.simulate_get(f"/oobi/{witness_aid}")
+        with (
+            patch.object(
+                witness.hab,
+                "replyToOobi",
+                wraps=witness.hab.replyToOobi,
+            ) as reply_to_oobi,
+        ):
+            response = client.simulate_get(f"/oobi/{witness_aid}")
+
         assert response.status_code == 200
+        assert response.content_type == "application/json+cesr"
+        assert reply_to_oobi.call_args.kwargs["pvrsn"] == kering.Vrsn_2_0
+        assert reply_to_oobi.call_args.kwargs["gvrsn"] == kering.Vrsn_2_0
+        assert reply_to_oobi.call_args.kwargs["kind"] == eventing.Kinds.json
         messages = _stream_messages(response.content)
 
-        # With the simpler `replyToOobi()` path, stored reply records come back
-        # in whatever version they were originally authored. This witness's
-        # endpoint metadata was created as v2, so the discovery replies remain
-        # v2 on the wire.
-        default_reply_versions = [version for version, ilk in messages if ilk == "rpy"]
-        assert default_reply_versions
-        assert all(version == kering.Vrsn_2_0 for version in default_reply_versions)
+        # Stored reply bodies keep the version in which they were authored while
+        # replyToOobi applies the requested genus to their attachments. This
+        # witness's endpoint metadata and requested genus are both v2.
+        replies = [result.serder for result in messages if result.serder.ilk == "rpy"]
+        assert replies
+        assert all(serder.pvrsn == kering.Vrsn_2_0 for serder in replies)
+        assert all(serder.kind == eventing.Kinds.json for serder in replies)
+
+        self_events = [
+            result
+            for result in messages
+            if result.serder.pre == witness_aid
+            and result.serder.ilk
+            in (
+                eventing.Ilks.icp,
+                eventing.Ilks.rot,
+                eventing.Ilks.ixn,
+                eventing.Ilks.dip,
+                eventing.Ilks.drt,
+            )
+        ]
+        assert self_events
+        assert all(result.serder.pvrsn == kering.Vrsn_2_0 for result in self_events)
+        assert all(result.sigers for result in self_events)
+        assert all(result.frcs for result in self_events)
 
         # Fetch the OOBI again and confirm the stored reply versions remain
         # stable across repeated requests.
@@ -211,9 +234,81 @@ def test_self_owned_oobi_reuses_stored_reply_record_versions():
 
         # The stored reply records keep their original authored v2 format
         # across repeated OOBI fetches too.
-        v2_reply_versions = [version for version, ilk in messages if ilk == "rpy"]
-        assert v2_reply_versions
-        assert all(version == kering.Vrsn_2_0 for version in v2_reply_versions)
+        replies = [result.serder for result in messages if result.serder.ilk == "rpy"]
+        assert replies
+        assert all(serder.pvrsn == kering.Vrsn_2_0 for serder in replies)
+        assert all(serder.kind == eventing.Kinds.json for serder in replies)
+
+
+def test_witnessed_controller_oobi_uses_serving_habitat_genus():
+    with (
+        habbing.openHab(
+            name="wan-oobi-seed",
+            transferable=False,
+            salt=b"0123456789feowit",
+            version=kering.Vrsn_2_0,
+            kind=eventing.Kinds.json,
+        ) as (_, seedHab),
+        habbing.openHab(
+            name="bob-oobi-controller",
+            salt=b"0123456789feoctl",
+            version=kering.Vrsn_1_0,
+            kind=eventing.Kinds.json,
+        ) as (_, bobHab),
+    ):
+        safe = basing.Baser(name=seedHab.name, temp=seedHab.temp)
+        witery = witnessing.Witnessery(db=safe, temp=seedHab.temp)
+        witness = witery.createWitness(aid=bobHab.pre)
+
+        witness.parser.parseOne(
+            ims=bytearray(bobHab.msgOwnInception()),
+            local=False,
+            version=kering.Vrsn_1_0,
+        )
+        rotation = bobHab.rotate(
+            adds=[witness.hab.pre],
+            version=kering.Vrsn_1_0,
+            gvrsn=kering.Vrsn_1_0,
+        )
+        witness.parser.parseOne(
+            ims=bytearray(rotation),
+            local=True,
+            version=kering.Vrsn_1_0,
+        )
+        assert bobHab.pre in witness.hab.kevers
+        assert witness.hab.pre in witness.hab.kevers[bobHab.pre].wits
+
+        endpoint = oobing.OOBIEnd(witery=witery)
+        app = falcon.App()
+        app.add_route("/oobi/{aid}", endpoint)
+        client = testing.TestClient(app)
+
+        with (
+            patch.object(witness.hab.db, "fullyWitnessed", return_value=True),
+            patch.object(
+                witness.hab,
+                "replyToOobi",
+                wraps=witness.hab.replyToOobi,
+            ) as reply_to_oobi,
+        ):
+            response = client.simulate_get(f"/oobi/{bobHab.pre}")
+
+        assert response.status_code == 200
+        assert response.content_type == "application/json+cesr"
+        assert reply_to_oobi.call_args.kwargs["pvrsn"] == kering.Vrsn_2_0
+        assert reply_to_oobi.call_args.kwargs["gvrsn"] == kering.Vrsn_2_0
+        assert reply_to_oobi.call_args.kwargs["kind"] == eventing.Kinds.json
+
+        messages = _stream_messages(response.content)
+        controller_events = [
+            result for result in messages if result.serder.pre == bobHab.pre
+        ]
+        assert controller_events
+        assert all(
+            result.serder.pvrsn == kering.Vrsn_1_0 for result in controller_events
+        )
+        assert all(result.sigers for result in controller_events)
+        assert all(result.frcs for result in controller_events)
 
 
 def test_delete_missing_witness_returns_not_found():


### PR DESCRIPTION
In this PR:
- get OOBI reply and replay versions from the witness habitat instead of hard coding v1
- create witness endpoint role and location records as v2 JSON
- keep onboarding and receipt tests explicit about the KERI and CESR versions they exercise, updated to be compatible with code changes

Part of keri-foundation/Development#45